### PR TITLE
Using `module.fail_json(msg=missing_required_lib('requests'))` format

### DIFF
--- a/plugins/modules/alert_contact_point.py
+++ b/plugins/modules/alert_contact_point.py
@@ -123,7 +123,7 @@ output:
       sample: email
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     import requests
     HAS_REQUESTS = True
@@ -213,7 +213,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-        module.fail_json("Missing package - `request` ")
+        module.fail_json(msg=missing_required_lib('requests'))
 
     is_error, has_changed, result = choice_map.get(
         module.params['state'])(module)

--- a/plugins/modules/alert_notification_policy.py
+++ b/plugins/modules/alert_notification_policy.py
@@ -161,7 +161,7 @@ output:
               ]
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     import requests
     HAS_REQUESTS = True
@@ -208,7 +208,7 @@ def main():
     module = AnsibleModule(argument_spec=module_args)
 
     if not HAS_REQUESTS:
-        module.fail_json("Missing package - `request` ")
+        module.fail_json(msg=missing_required_lib('requests'))
 
     is_error, has_changed, result = alert_notification_policy(module)
 

--- a/plugins/modules/cloud_api_key.py
+++ b/plugins/modules/cloud_api_key.py
@@ -71,7 +71,7 @@ EXAMPLES = '''
     state: absent
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     import requests
     HAS_REQUESTS = True
@@ -132,7 +132,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-        module.fail_json("Missing package - `request` ")
+        module.fail_json(msg=missing_required_lib('requests'))
 
     is_error, has_changed, result = choice_map.get(
         module.params['state'])(module)

--- a/plugins/modules/cloud_plugin.py
+++ b/plugins/modules/cloud_plugin.py
@@ -92,7 +92,7 @@ RETURN = r'''
     sample: "grafana-github-datasource"
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     import requests
     HAS_REQUESTS = True
@@ -156,7 +156,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-        module.fail_json("Missing package - `request` ")
+        module.fail_json(msg=missing_required_lib('requests'))
 
     is_error, has_changed, result = choice_map.get(
         module.params['state'])(module)

--- a/plugins/modules/cloud_stack.py
+++ b/plugins/modules/cloud_stack.py
@@ -125,7 +125,7 @@ RETURN = r'''
     sample: "https://stackname.grafana.net"
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     import requests
     HAS_REQUESTS = True
@@ -199,7 +199,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-        module.fail_json("Missing package - `request` ")
+        module.fail_json(msg=missing_required_lib('requests'))
 
     is_error, has_changed, result = choice_map.get(
         module.params['state'])(module)

--- a/plugins/modules/dashboard.py
+++ b/plugins/modules/dashboard.py
@@ -162,7 +162,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-       module.fail_json(msg=missing_required_lib('requests'))
+        module.fail_json(msg=missing_required_lib('requests'))
 
     is_error, has_changed, result = choice_map.get(
         module.params['state'])(module)

--- a/plugins/modules/dashboard.py
+++ b/plugins/modules/dashboard.py
@@ -106,7 +106,7 @@ output:
       sample: "Ansible Integration Test"
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     import requests
     HAS_REQUESTS = True
@@ -162,7 +162,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-        module.fail_json("Missing package - `request` ")
+       module.fail_json(msg=missing_required_lib('requests'))
 
     is_error, has_changed, result = choice_map.get(
         module.params['state'])(module)

--- a/plugins/modules/datasource.py
+++ b/plugins/modules/datasource.py
@@ -107,7 +107,7 @@ output:
       sample: "Datasource added"
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     import requests
     HAS_REQUESTS = True
@@ -171,7 +171,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-        module.fail_json("Missing package - `request` ")
+        module.fail_json(msg=missing_required_lib('requests'))
 
     is_error, has_changed, result = choice_map.get(
         module.params['state'])(module)

--- a/plugins/modules/folder.py
+++ b/plugins/modules/folder.py
@@ -154,7 +154,7 @@ output:
       sample: "Folder foldername deleted"
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     import requests
     HAS_REQUESTS = True
@@ -226,7 +226,7 @@ def main():
     )
 
     if not HAS_REQUESTS:
-        module.fail_json("Missing package - `request` ")
+        module.fail_json(msg=missing_required_lib('requests'))
 
     is_error, has_changed, result = choice_map.get(
         module.params['state'])(module)


### PR DESCRIPTION
Using module.fail_json(msg=missing_required_lib('requests')) format as recommended by the Ansible Community. To be merged when releasing `1.0.4`