### PR TITLE
Add ReadWritePaths

### DIFF
--- a/roles/grafana_agent/tasks/install/directories.yaml
+++ b/roles/grafana_agent/tasks/install/directories.yaml
@@ -23,4 +23,4 @@
         state: directory
         owner: root
         group: "{{ grafana_agent_user_group }}"
-        mode: 0755
+        mode: 0775

--- a/roles/grafana_agent/templates/grafana-agent.service.j2
+++ b/roles/grafana_agent/templates/grafana-agent.service.j2
@@ -11,7 +11,7 @@ After=local-fs.target
 Type=simple
 User={{ grafana_agent_user }}
 Group={{ grafana_agent_user_group }}
-WorkingDirectory={{ grafana_agent_config_dir }}
+WorkingDirectory={{ grafana_agent_data_dir }}
 EnvironmentFile={{ grafana_agent_config_dir }}/{{ grafana_agent_env_file}}
 
 ExecStart={{ grafana_agent_install_dir }}/{{ grafana_agent_binary }} \
@@ -39,6 +39,7 @@ ProtectKernelTunables=yes
 {% else %}
 ProtectSystem=full
 {% endif %}
+ReadWritePaths=/tmp {{ grafana_agent_data_dir }} {{ grafana_agent_positions_dir }} {{ grafana_agent_wal_dir }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd ReadWritePaths is added in order to allow writing data with ProtectSystem=strict or full . https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Sandboxing

Also changed WorkingDirectory to {{ grafana_agent_data_dir }}. In this case, if wal_directory is undefined in the config, then it would work with agent's default value of "", see https://github.com/grafana/agent/issues/2217