### PR TITLE
Configurable agent user groups (#40)

### DIFF
--- a/roles/grafana_agent/README.md
+++ b/roles/grafana_agent/README.md
@@ -26,6 +26,7 @@ All variables which can be overridden are stored in [./defaults/main.yaml](./def
 | `grafana_agent_mode` | `static` | mode to run Grafana Agent in. Can be "flow" or "static", [Flow Docs](https://grafana.com/docs/agent/latest/flow/) |
 | `grafana_agent_user` | `grafana-agent` | os user to create for the agent to run as |
 | `grafana_agent_user_group` | `grafana-agent` | os user group to create for the agent |
+| `grafana_agent_user_groups` | `[]` | Configurable user groups that the grafana agent can be put in so that it can access logs |
 | `grafana_agent_user_shell` | `/usr/sbin/nologin` | the shell for the user |
 | `grafana_agent_user_createhome` | `false` | whether or not to create a home directory for the user |
 | `grafana_agent_local_binary_file` | `""` | full path to the local binary if already downloaded or built on the controller, this should only be set, if ansible is not downloading the binary and you have manually downloaded the binary |

--- a/roles/grafana_agent/defaults/main.yaml
+++ b/roles/grafana_agent/defaults/main.yaml
@@ -39,6 +39,10 @@ grafana_agent_user: grafana-agent
 # os user group to create for the agent
 grafana_agent_user_group: grafana-agent
 
+# Configurable user groups that the grafana agent can be put in so that it can access logs
+# (See https://github.com/grafana/grafana-ansible-collection/issues/40)
+grafana_agent_user_groups: []
+
 # the shell for the user
 grafana_agent_user_shell: /usr/sbin/nologin
 

--- a/roles/grafana_agent/tasks/install/user-group.yaml
+++ b/roles/grafana_agent/tasks/install/user-group.yaml
@@ -41,8 +41,7 @@
       ansible.builtin.user:
         name: "{{ grafana_agent_user }}"
         comment: "Grafana Agent Account"
-        groups:
-          - "{{ grafana_agent_user_group }}"
+        groups: "{{ [ grafana_agent_user_group ] + grafana_agent_user_groups }}"
         system: true
         shell: "{{ grafana_agent_user_shell }}"
         createhome: "{{ grafana_agent_user_createhome }}"


### PR DESCRIPTION
This pull request adds a variable for adding the grafana agent user to additional groups. Fixes #40 