### PR TITLE
Remove explicit user creation check

### DIFF
--- a/roles/grafana_agent/tasks/configure.yaml
+++ b/roles/grafana_agent/tasks/configure.yaml
@@ -29,7 +29,7 @@
     group: root
     state: link
 
-- name: Overwrite/Create Grafana Agent Service
+- name: Overwrite/Create Grafana Agent service
   ansible.builtin.template:
     src: grafana-agent.service.j2
     dest: "{{ _grafana_agent_systemd_dir }}/{{ _grafana_agent_systemd_unit }}"
@@ -37,7 +37,7 @@
     group: root
     mode: 0644
 
-- name: Create the Service Environment File
+- name: Create the Service Environment file
   ansible.builtin.template:
     src: EnvironmentFile.j2
     dest: "{{ grafana_agent_config_dir }}/{{ grafana_agent_env_file }}"
@@ -45,7 +45,7 @@
     group: "{{ grafana_agent_user_group }}"
     mode: 0640
 
-- name: Create Grafana Agent Config
+- name: Create Grafana Agent config
   ansible.builtin.template:
     src: config.yaml.j2
     dest: "{{ grafana_agent_config_dir }}/{{ grafana_agent_config_filename }}"
@@ -55,7 +55,7 @@
     mode: 0640
   when: grafana_agent_provisioned_config_file | length == 0
 
-- name: Copy Grafana Agent Config
+- name: Copy Grafana Agent config
   ansible.builtin.copy:
     src: "{{ grafana_agent_provisioned_config_file }}"
     dest: "{{ grafana_agent_config_dir }}/{{ grafana_agent_config_filename }}"

--- a/roles/grafana_agent/tasks/configure.yaml
+++ b/roles/grafana_agent/tasks/configure.yaml
@@ -18,7 +18,7 @@
           - _grafana_agent_systemd_unit not in services
 
 # these tasks are ran in both install and configure, as directories could have changed
-- name: Configure Directories
+- name: Configure directories
   ansible.builtin.import_tasks: install/directories.yaml
 
 - name: Create a symbolic link

--- a/roles/grafana_agent/tasks/install/user-group.yaml
+++ b/roles/grafana_agent/tasks/install/user-group.yaml
@@ -27,16 +27,6 @@
 
 - name: Grafana Agent user creation
   block:
-    - name: "Check if the user exists ({{ grafana_agent_user }})"
-      ansible.builtin.getent:
-        database: passwd
-        key: "{{ grafana_agent_user }}"
-        fail_key: false
-
-    - name: Set whether not the user exists
-      ansible.builtin.set_fact:
-        __grafana_agent_user_exists: "{{ ansible_facts.getent_passwd[grafana_agent_user] is not none }}"
-
     - name: Add user "{{ grafana_agent_user }}"
       ansible.builtin.user:
         name: "{{ grafana_agent_user }}"
@@ -45,11 +35,4 @@
         system: true
         shell: "{{ grafana_agent_user_shell }}"
         createhome: "{{ grafana_agent_user_createhome }}"
-      when: not __grafana_agent_user_exists and grafana_agent_user != 'root'
-
-    - name: Grafana Agent user exists
-      ansible.builtin.debug:
-        msg: |-
-          The user \"{{ grafana_agent_user }}\" already exists and will not be modified,
-          if modifying permissions please perform a separate task
-      when: __grafana_agent_user_exists
+      when: grafana_agent_user != 'root'

--- a/roles/grafana_agent/tasks/install/user-group.yaml
+++ b/roles/grafana_agent/tasks/install/user-group.yaml
@@ -30,7 +30,7 @@
     - name: Add user "{{ grafana_agent_user }}"
       ansible.builtin.user:
         name: "{{ grafana_agent_user }}"
-        comment: "Grafana Agent Account"
+        comment: "Grafana Agent account"
         groups: "{{ [ grafana_agent_user_group ] + grafana_agent_user_groups }}"
         system: true
         shell: "{{ grafana_agent_user_shell }}"

--- a/roles/grafana_agent/tasks/preflight/download.yaml
+++ b/roles/grafana_agent/tasks/preflight/download.yaml
@@ -17,7 +17,7 @@
       ansible.builtin.set_fact:
         grafana_agent_version: "{{ _grafana_agent_version_request.stdout }}"
 
-    - name: Grafana Agent Version to Download
+    - name: Grafana Agent Version to download
       ansible.builtin.debug:
         var: grafana_agent_version
 

--- a/roles/grafana_agent/tasks/preflight/download.yaml
+++ b/roles/grafana_agent/tasks/preflight/download.yaml
@@ -17,7 +17,7 @@
       ansible.builtin.set_fact:
         grafana_agent_version: "{{ _grafana_agent_version_request.stdout }}"
 
-    - name: Grafana Agent Version to download
+    - name: Grafana Agent version to download
       ansible.builtin.debug:
         var: grafana_agent_version
 


### PR DESCRIPTION
Fixes #43 .
As this check is done in ansible user module already, so it is safe to run it anytime due to module's idempotency: 
https://docs.ansible.com/ansible/latest/reference_appendices/glossary.html#term-Idempotency .