### PR TITLE
Remove agent installation custom check

### DIFF
--- a/roles/grafana_agent/tasks/main.yaml
+++ b/roles/grafana_agent/tasks/main.yaml
@@ -22,7 +22,6 @@
         - grafana_agent_install
   tags:
     - grafana_agent_install
-  when: __grafana_agent_do_install
 
 - name: Configuration tasks
   ansible.builtin.include_tasks:

--- a/roles/grafana_agent/tasks/preflight.yaml
+++ b/roles/grafana_agent/tasks/preflight.yaml
@@ -10,12 +10,3 @@
 
 - name: Download variable checks
   ansible.builtin.import_tasks: preflight/download.yaml
-
-- name: Set whether or not to do the install
-  ansible.builtin.set_fact:
-    __grafana_agent_do_install: >-
-      {{ not __grafana_agent_is_installed.stat.exists or __grafana_agent_installed_version is version_compare(grafana_agent_version, '<') }}
-
-- name: Do install
-  ansible.builtin.debug:
-    var: __grafana_agent_do_install


### PR DESCRIPTION
This MR removes the custom version check in favor of ansible native idempotency feature

Resolves #50 

