### PR TITLE
Move _grafana_agent_base_download_url from /vars to /defaults

### DIFF
--- a/roles/grafana_agent/README.md
+++ b/roles/grafana_agent/README.md
@@ -14,6 +14,7 @@ All variables which can be overridden are stored in [./defaults/main.yaml](./def
 | Variable | Default | Description |
 | :------ | :------ | :--------- |
 | `grafana_agent_version` | `latest` | version of the agent to install |
+| `grafana_agent_base_download_url` | `https://github.com/{{ _grafana_agent_github_org }}/{{ _grafana_agent_github_repo }}/releases/download` | base download url. Github or mirror to download from |
 | `grafana_agent_install_dir` | `/opt/grafana-agent/bin` | directory to install the binary to |
 | `grafana_agent_binary` | `grafana-agent` | name to use for the binary |
 | `grafana_agent_config_dir` | `/etc/grafana-agent` | directory to store the configuration files in |

--- a/roles/grafana_agent/defaults/main.yaml
+++ b/roles/grafana_agent/defaults/main.yaml
@@ -2,6 +2,9 @@
 # version of the agent to install
 grafana_agent_version: latest
 
+# base download url. Github or mirror to download from
+grafana_agent_base_download_url: "https://github.com/{{ _grafana_agent_github_org }}/{{ _grafana_agent_github_repo }}/releases/download"
+
 # directory to install the binary to
 grafana_agent_install_dir: /opt/grafana-agent/bin
 

--- a/roles/grafana_agent/tasks/preflight/download.yaml
+++ b/roles/grafana_agent/tasks/preflight/download.yaml
@@ -24,7 +24,7 @@
 - name: Set the Grafana Agent download URL
   ansible.builtin.set_fact:
     _grafana_agent_download_url: |-
-      {{ _grafana_agent_base_download_url }}/v{{ grafana_agent_version }}/{{ _grafana_agent_download_archive_file }}
+      {{ grafana_agent_base_download_url }}/v{{ grafana_agent_version }}/{{ _grafana_agent_download_archive_file }}
 
 - name: Grafana Agent download URL
   ansible.builtin.debug:

--- a/roles/grafana_agent/vars/main.yaml
+++ b/roles/grafana_agent/vars/main.yaml
@@ -1,7 +1,6 @@
 ---
 _grafana_agent_github_org: grafana
 _grafana_agent_github_repo: agent
-_grafana_agent_base_download_url: "https://github.com/{{ _grafana_agent_github_org }}/{{ _grafana_agent_github_repo }}/releases/download"
 
 # set the go cpu arch
 _download_cpu_arch_map:


### PR DESCRIPTION
Move _grafana_agent_base_download_url from vars to defaults to allow overriding.

This can be useful to download agent from local mirror, reusing arch detection logic of this role.