### PR TITLE
Create local dashboard directory in check mode

### DIFF
--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -7,6 +7,7 @@
     state: directory
   register: __tmp_dashboards
   changed_when: false
+  check_mode: true
 
 - name: "Download grafana.net dashboards"
   become: false


### PR DESCRIPTION
Another small fix. When you run the role in check mode the directory also needs to be created. Otherwise the run will fail.