### PR TITLE
Add check for Curl and failure step if Agent Version is not retrieved

### DIFF
--- a/roles/grafana_agent/tasks/preflight/download.yaml
+++ b/roles/grafana_agent/tasks/preflight/download.yaml
@@ -1,4 +1,14 @@
 ---
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: Fail if Curl is not installed
+  ansible.builtin.fail:
+    msg: "curl is not installed!"
+  when: "'curl' not in ansible_facts.packages"
+
+
 - name: Get Grafana Agent version from Github
   when: grafana_agent_version == 'latest' and not __grafana_agent_local_install
   block:
@@ -12,6 +22,11 @@
       delegate_to: localhost
       become: false
       register: _grafana_agent_version_request
+
+    - name: Fail if cannot get Grafana Agent Version
+      ansible.builtin.fail:
+        msg: Issue getting the Grafana Agent Version
+      when: _grafana_agent_version_request == ""
 
     - name: Set the Grafana Agent version
       ansible.builtin.set_fact:


### PR DESCRIPTION
resolves https://github.com/grafana/grafana-ansible-collection/issues/97 and https://github.com/grafana/grafana-ansible-collection/issues/75