### PR TITLE
Use 'ansible_system' env variable to detect os type

### DIFF
--- a/roles/grafana_agent/vars/main.yaml
+++ b/roles/grafana_agent/vars/main.yaml
@@ -13,14 +13,7 @@ _download_cpu_arch_map:
 _grafana_agent_cpu_arch: "{{ _download_cpu_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
 # set the go os family
-_download_os_family_map:
-  alpine: linux
-  debian: linux
-  redhat: linux
-  darwin: darwin
-  freebsd: freebsd
-
-_grafana_agent_os_family: "{{ _download_os_family_map[ansible_os_family | lower] | default(ansible_os_family | lower) }}"
+_grafana_agent_os_family: "{{ ansible_system | lower }}"
 
 # set the name of the archive file to download
 _grafana_agent_download_archive_file: "grafana-agent-{{ _grafana_agent_os_family }}-{{ _grafana_agent_cpu_arch }}.zip"


### PR DESCRIPTION
This ansible fact can be 'Darwin', 'FreeBSD' or 'Linux'. Otherwise, download link can be broken for custom os-families if 'ansible_os_family' is used.

https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html

<img width="463" alt="image" src="https://github.com/grafana/grafana-ansible-collection/assets/14870891/5891b47c-3cb4-4c86-9dc1-9511c3e636a5">
