### PR TITLE
Create missing notification directory

### DIFF
--- a/roles/grafana/tasks/configure.yml
+++ b/roles/grafana/tasks/configure.yml
@@ -13,6 +13,7 @@
     - path: "/etc/grafana/provisioning/datasources"
     - path: "/etc/grafana/provisioning/dashboards"
     - path: "/etc/grafana/provisioning/notifiers"
+    - path: "/etc/grafana/provisioning/notification"
     - path: "/etc/grafana/provisioning/plugins"
     - path: "{{ grafana_logs_dir }}"
       owner: grafana


### PR DESCRIPTION
With this Commit, the missing directory /etc/grafana/provisioning/notification for the "Create/Delete/Update alert notifications channels (provisioning)" tasks will be created.

See https://github.com/grafana/grafana-ansible-collection/issues/112