### PR TITLE
remove check_mode from create local directory task

### DIFF
--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -7,7 +7,6 @@
     state: directory
   register: __tmp_dashboards
   changed_when: false
-  check_mode: true
 
 - name: "Download grafana.net dashboards"
   become: false


### PR DESCRIPTION
it looks like checkmode is not working for the "Create local grafana dashboard directory" task.

See https://github.com/grafana/grafana-ansible-collection/issues/107