### PR TITLE
Drop curl check

### DIFF
--- a/roles/grafana_agent/README.md
+++ b/roles/grafana_agent/README.md
@@ -5,7 +5,9 @@ and Fedora linux distributions.
 
 ## Requirements
 
-To use this role, You need a YAML file having the Grafana Agent configuration
+Please ensure that `curl` is intalled on Ansible controller.
+
+To use this role, You need a YAML file having the Grafana Agent configuration.
 
 ## Role Variables
 

--- a/roles/grafana_agent/tasks/preflight/download.yaml
+++ b/roles/grafana_agent/tasks/preflight/download.yaml
@@ -1,14 +1,4 @@
 ---
-- name: Gather the package facts
-  ansible.builtin.package_facts:
-    manager: auto
-
-- name: Fail if Curl is not installed
-  ansible.builtin.fail:
-    msg: "curl is not installed!"
-  when: "'curl' not in ansible_facts.packages"
-
-
 - name: Get Grafana Agent version from Github
   when: grafana_agent_version == 'latest' and not __grafana_agent_local_install
   block:


### PR DESCRIPTION
Curl is required on localhost, not target host. This check could fail the playbook, if curl is missing on remote host (where it is actually not needed). 

Decided not to reimplement this check on ansible controller, as it may be not that easy (if you run ansible controller on MacOS or in containers).