### PR TITLE
grafana-agent: Fix check mode

### DIFF
--- a/roles/grafana_agent/tasks/ga-started.yaml
+++ b/roles/grafana_agent/tasks/ga-started.yaml
@@ -10,9 +10,10 @@
   retries: 3
   delay: 5
   changed_when: false
+  when: not ansible_check_mode
 
 - name: Check system logs if Grafana Agent is not started
-  when: _result.status != 200
+  when: not ansible_check_mode and _result.status != 200
   block:
   - name: Run journalctl
     ansible.builtin.shell:

--- a/roles/grafana_agent/tasks/install/download-install.yaml
+++ b/roles/grafana_agent/tasks/install/download-install.yaml
@@ -43,3 +43,4 @@
         mode: 0755
         owner: root
         group: root
+      ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/grafana_agent/tasks/install/download-install.yaml
+++ b/roles/grafana_agent/tasks/install/download-install.yaml
@@ -43,4 +43,4 @@
         mode: 0755
         owner: root
         group: root
-      ignore_errors: "{{ ansible_check_mode }}"
+      when: not ansible_check_mode


### PR DESCRIPTION
This should make the grafana-agent role work in ansible's `--check` mode. I tested this against my homelab ansible playbook, and it works when there's no changes, and when the config changes. I did not test if it'll work for a fresh install because I tested installing the agent by itself before starting on this PR.

Fixes #123 