### PR TITLE
Change handler to systemd

### DIFF
--- a/roles/grafana_agent/handlers/main.yaml
+++ b/roles/grafana_agent/handlers/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Restart Grafana Agent
   become: true
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: grafana-agent
     state: restarted
     daemon_reload: true


### PR DESCRIPTION
systemd module is better to use as service module is targeted to restart SysV services. And here we use systemd service.