### PR TITLE
management of the config.river with the conversion of the config.yaml

### DIFF
--- a/roles/grafana_agent/tasks/configure.yaml
+++ b/roles/grafana_agent/tasks/configure.yaml
@@ -40,6 +40,11 @@
   notify: "restart grafana-agent"
   when: grafana_agent_provisioned_config_file | length == 0
 
+- name: Create Grafana Agent River Config if flow mode for Grafana Agent
+   ansible.builtin.shell: "AGENT_MODE=flow {{ grafana_agent_install_dir }}/grafana-agent convert -f static {{ grafana_agent_config_dir }}/{{ grafana_agent_config_filename }} -o {{ grafana_agent_config_dir }}/{{ grafana_agent_config_filename }}"
+  notify: "restart grafana-agent"
+  when: grafana_agent_provisioned_config_file | length == 0
+
 - name: Copy Grafana Agent config
   ansible.builtin.copy:
     src: "{{ grafana_agent_provisioned_config_file }}"

--- a/roles/grafana_agent/templates/config.yaml.j2
+++ b/roles/grafana_agent/templates/config.yaml.j2
@@ -22,12 +22,14 @@ metrics:
 logs:
   {{ grafana_agent_logs_config | to_nice_yaml(indent=2,sort_keys=False) | indent(2) }}
 
+{% if grafana_agent_mode == 'static' %}
 #################################################################################################
 #                             Configures traces collection                                      #
 #################################################################################################
 # Docs: https://grafana.com/docs/agent/latest/configuration/traces-config/
 traces:
   {{ grafana_agent_traces_config | to_nice_yaml(indent=2,sort_keys=False) | indent(2) }}
+{% endif %}
 
 #################################################################################################
 #                          Configures integrations for the agent                                #


### PR DESCRIPTION
This fork will permit to realize a config.river of the flow mode thanks to the config.yaml of the static mode.

The objective is to deploy a grafana agent in mode flow with a dynamic configuration and not only with a config.river already configured before the deployement by ansible.


The solution that i have used it to convert the static format to the flow format is the following command:

- name: Create Grafana Agent River Config if flow mode for Grafana Agent
   ansible.builtin.shell: "AGENT_MODE=flow {{ grafana_agent_install_dir }}/grafana-agent convert -f static {{ grafana_agent_config_dir }}/{{ grafana_agent_config_filename }} -o {{ grafana_agent_config_dir }}/{{ grafana_agent_config_filename }}"
  notify: "restart grafana-agent"
  when: grafana_agent_provisioned_config_file | length == 0


I have made any tests and it is ok for me

Regards
Ludovic