### PR TITLE
ExecStartPre and EnvironmentFile settings to system unit file

### DIFF
--- a/roles/grafana_agent/README.md
+++ b/roles/grafana_agent/README.md
@@ -22,6 +22,8 @@ All variables which can be overridden are stored in [./defaults/main.yaml](./def
 | `grafana_agent_config_dir` | `/etc/grafana-agent` | directory to store the configuration files in |
 | `grafana_agent_config_filename` | `config.yaml` | name of the configuration file for the agent |
 | `grafana_agent_env_file` | `service.env` | name of the environment file loaded by the system unit file |
+| `grafana_agent_optional_env_file` | `""` | when specifying an additional environment file loaded by the system unit file |
+| `grafana_agent_exec_start_pre` | `""` | add an ExecStart to the systemd unit file |
 | `grafana_agent_local_tmp_dir` | `/tmp/grafana-agent` | temporary directory to create on the controller/localhost where the archive will be downloaded to |
 | `grafana_agent_data_dir` | `/var/lib/grafana-agent` | the data directory to create for the wal and positions |
 | `grafana_agent_wal_dir` | `"{{ grafana_agent_data_dir }}/data"` | wal directory to use, should be a sub-folder of grafana_agent_data_dir, will automatically be created when the agent starts |

--- a/roles/grafana_agent/defaults/main.yaml
+++ b/roles/grafana_agent/defaults/main.yaml
@@ -20,6 +20,12 @@ grafana_agent_config_filename: config.yaml
 # name of the environment file loaded by the system unit file
 grafana_agent_env_file: service.env
 
+# when specifying an additional environment file loaded by the system unit file
+grafana_agent_optional_env_file: ""
+
+# add an ExecStart to the systemd unit file
+grafana_agent_exec_start_pre: ""
+
 # temporary directory to create on the controller/localhost where the archive will be downloaded to
 grafana_agent_local_tmp_dir: /tmp/grafana-agent
 

--- a/roles/grafana_agent/templates/grafana-agent.service.j2
+++ b/roles/grafana_agent/templates/grafana-agent.service.j2
@@ -14,6 +14,12 @@ WorkingDirectory={{ grafana_agent_data_dir }}
 Environment={{key}}={{value}}
 {% endfor %}
 EnvironmentFile={{ grafana_agent_config_dir }}/{{ grafana_agent_env_file}}
+{% if grafana_agent_optional_env_file | length > 0  %}
+EnvironmentFile={{ grafana_agent_optional_env_file }}
+{% endif -%}
+{% if grafana_agent_exec_start_pre | length > 0  %}
+ExecStartPre={{ grafana_agent_exec_start_pre }}
+{% endif -%}
 
 {% if grafana_agent_mode == 'flow' %}
 ExecStart={{ grafana_agent_install_dir }}/{{ grafana_agent_binary }} run \


### PR DESCRIPTION
I propose adding the capability to configure ExecStartPre and EnvironmentFile in the system unit file. This enhancement allows us to dynamically define variables before running the Grafana Agent, enabling their use in config.yaml.

For example, this change makes it possible to fetch EC2 tags and use them as labels for metrics.

Below is an example script that retrieves the instance ID, queries for the project tag associated with that EC2 instance, and writes it to an environment file. This tag is then used as an external label in metrics configuration.

```
#! /bin/sh

export INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
ENV_FILE=/var/lib/grafana-agent/aws-env
AWS_PROJECT_TAG=$(aws ec2 describe-instances --region ap-northeast-1 --instance-ids "${INSTANCE_ID}" --query 'Reservations[0].Instances[0].Tags[?Key==`Project`]|[0].Value' --output text)

echo AWS_PROJECT_TAG="${AWS_PROJECT_TAG}" > ${ENV_FILE}
```

This environment variable is then referenced in the config.yaml for the Grafana Agent as shown below:

```
metrics:
  global:
    external_labels:
      project: ${AWS_PROJECT_TAG}
```