### PR TITLE
delete obsolete variable login_remember_days

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -55,7 +55,6 @@ grafana_security:
   admin_user: admin
   admin_password: ""
 #  secret_key: ""
-#  login_remember_days: 7
 #  cookie_username: grafana_user
 #  cookie_remember_name: grafana_remember
 #  disable_gravatar: true


### PR DESCRIPTION
I've removed obsolete variable `login_remember_days` as it is not referenced anywhere. Thanks, Francesco