### PR TITLE
integrate sles legacy init-script support

### DIFF
--- a/roles/grafana/vars/distro/suse.yml
+++ b/roles/grafana/vars/distro/suse.yml
@@ -1,2 +1,6 @@
 ---
 grafana_package: "grafana{{ (grafana_version != 'latest') | ternary('-' ~ grafana_version, '') }}"
+# https://unix.stackexchange.com/questions/534463/cant-enable-grafana-on-boot-in-fedora-because-systemd-sysv-install-missing
+# applies to SuSe too
+_grafana_dependencies:
+  - insserv-compat


### PR DESCRIPTION
added a depending package (insserv-compat) to avoid strange errors on a fresh sles installation (/etc/init.d/.. not found)