### PR TITLE
fix: increase create a Grafana Cloud stack sleep period

### DIFF
--- a/tests/integration/targets/create_cloud_stack/tasks/main.yml
+++ b/tests/integration/targets/create_cloud_stack/tasks/main.yml
@@ -13,6 +13,15 @@
     that:
       - create_result.url == "https://" + "{{ test_stack_name }}" + ".grafana.net"
 
-- name: Sleep for 90 seconds
-  ansible.builtin.wait_for:
-    timeout: 90
+- name: "{{ java_app_name }} - Check health through health endpoint"
+  ansible.builtin.uri:
+    url: "https://{{ test_stack_name }}.grafana.net"
+    method: GET
+    return_content: true
+    status_code: 200
+    timeout: 5
+  register: _healthcheck_uri
+  until: ((_healthcheck_uri.content | default('{}', true) | from_json).status | default('Unknown')) == 'UP'
+  retries: 15
+  delay: 15
+

--- a/tests/integration/targets/create_cloud_stack/tasks/main.yml
+++ b/tests/integration/targets/create_cloud_stack/tasks/main.yml
@@ -13,6 +13,6 @@
     that:
       - create_result.url == "https://" + "{{ test_stack_name }}" + ".grafana.net"
 
-- name: Sleep for 45 seconds
+- name: Sleep for 90 seconds
   ansible.builtin.wait_for:
-    timeout: 45
+    timeout: 90


### PR DESCRIPTION
PR to fix failing integration tests.
Integration tests fail since the stack is not initialized before the test starts.
Added a polling mechanism to check whether the stack returns 200.

