### PR TITLE
Add a new config part to configure KeyCloak based auth

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -145,6 +145,9 @@ grafana_ldap: {}
 #        - group_dn: "cn=alternative_admins,ou=groups,dc=grafana,dc=org"
 #          org_role: Admin
 
+# Grafana KeyCloak auth
+grafana_auth_generic_oauth: {}
+
 grafana_session: {}
 #  provider: file
 #  provider_config: "sessions"

--- a/roles/grafana/templates/grafana.ini.j2
+++ b/roles/grafana/templates/grafana.ini.j2
@@ -212,3 +212,11 @@ provider = {{ grafana_image_storage.provider }}
 {{ k }} = {{ v }}
 {%   endfor %}
 {% endif %}
+
+# Oauth_Keycloack
+{% if grafana_auth_generic_oauth != {} %}
+[auth.generic_oauth]
+{%   for k,v in grafana_auth_generic_oauth.items() %}
+{{ k }} = {{ v }}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
The new config part is necessary to configure a KeyCloak based authentication described in the following documentation: https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/keycloak/#configure-keycloak-oauth2-authentication.

This brings more flexibility to the Grafana configuration process made by the Ansible role.