### PR TITLE
fix: Uninstall Loki and Mimir 

### DIFF
--- a/roles/loki/tasks/uninstall.yml
+++ b/roles/loki/tasks/uninstall.yml
@@ -18,6 +18,7 @@
   ansible.builtin.apt:
     name: "loki"
     state: absent
+    purge: true
   when: ansible_os_family == 'Debian'
 
 - name: Ensure that Loki firewalld rule is not present - tcp port {{ loki_http_listen_port }}

--- a/roles/mimir/tasks/uninstall.yml
+++ b/roles/mimir/tasks/uninstall.yml
@@ -18,6 +18,7 @@
   ansible.builtin.apt:
     name: "mimir"
     state: absent
+    purge: true
   when: ansible_os_family == 'Debian'
 
 - name: Ensure that Mimir firewalld rule is not present - tcp port {{ mimir_http_listen_port }}


### PR DESCRIPTION
I'd like to address the issue in the Loki and Mimir roles where the uninstall process lacks the purge option.
This is necessary for proper cleanup, especially on Debian/Ubuntu systems. This issue doesn't affect RedHat systems as they use RPM.

For illustration, you can execute `dpkg -l | grep loki` or `dpkg -l | grep mimir` after performing the uninstallation.
In the scenario, if you deploy, remove, and then redeploy, it would fail because the postinst script isn't executed during deployment.

Background info:
To ensure this problem is avoided, you can easily verify that user creation is done in `postinst` of deb package.

1. Download the Loki Deb package.
2. Extract it using `ar -x <package>.deb`.
3. Extract the control file.
4. Open the `postinst` file, where you'll find the `cleanInstall()` function responsible for handling user creation:
```bash
# Create the user
if ! id loki > /dev/null 2>&1 ; then
    adduser --system --shell /bin/false "loki"
fi
```

Once this is merged, there should be no issues when deploying, removing, and then redeploying on Debian/Ubuntu.