### PR TITLE
Disable legacy alerting

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -176,8 +176,8 @@ grafana_smtp: {}
 #  from_address:
 
 # Enable grafana alerting mechanism
-grafana_alerting:
-  execute_alerts: true
+grafana_alerting: {}
+#  execute_alerts: true
 #  error_or_timeout: 'alerting'
 #  nodata_or_nullvalues: 'no_data'
 #  concurrent_render_limit: 5

--- a/roles/grafana/templates/grafana.ini.j2
+++ b/roles/grafana/templates/grafana.ini.j2
@@ -113,9 +113,9 @@ versions_to_keep = 20
 enabled = true
 path = {{ grafana_data_dir }}/dashboards
 
+{% if grafana_alerting != {} %}
 # Alerting
 [alerting]
-{% if grafana_alerting != {} %}
 enabled = true
 {%   for k,v in grafana_alerting.items() %}
 {%     if k != 'enabled' %}
@@ -124,8 +124,8 @@ enabled = true
 {%   endfor %}
 {% else %}
 enabled = false
-{% endif %}
 
+{% endif %}
 # SMTP and email config
 {% if grafana_smtp != {} %}
 [smtp]


### PR DESCRIPTION
Grafana 11 has been released and removes the legacy alerting. Set the `grafana_alerting` value to an empty dict to disable it by default. But keep the existing alerting config option for users on older versions.