### PR TITLE
Update grafana.ini.j2

### DIFF
--- a/roles/grafana/templates/grafana.ini.j2
+++ b/roles/grafana/templates/grafana.ini.j2
@@ -114,7 +114,7 @@ enabled = true
 path = {{ grafana_data_dir }}/dashboards
 
 # Alerting
-[alerting]
+[unified_alerting]
 {% if grafana_alerting != {} %}
 enabled = true
 {%   for k,v in grafana_alerting.items() %}


### PR DESCRIPTION
Changed the legacy setting `[alerting]` to `[unified_alerting]`. Grafana-server will not start with the legacy setting enabled.