### PR TITLE
Update Alloy variables to use the `grafana_alloy_` namespace so they are unique

### DIFF
--- a/roles/alloy/README.md
+++ b/roles/alloy/README.md
@@ -14,22 +14,22 @@ Available variables with their default values are listed below (`defaults/main.y
 
 | Variable Name         | Description                                                          | Default Value                                                       |
 |-----------------------|----------------------------------------------------------------------|---------------------------------------------------------------------|
-| `version`             | The version of Grafana Alloy to be installed.                        | "1.0.0"                                                             |
-| `arch_mapping`        | A mapping of common architecture names to Grafana Alloy binaries.    | `{'x86_64': 'amd64', 'aarch64': 'arm64', 'armv7l': 'armhf', 'i386': 'i386', 'ppc64le': 'ppc64le'}` |
-| `arch`                | The architecture of the current machine.                             | Based on `ansible_architecture` lookup, defaults to 'amd64'.       |
-| `binary_url`          | URL to Grafana Alloy binary for the specific version and architecture. | Constructed URL based on `version` and `arch` variables.          |
-| `service_name`        | The name to be used for the Grafana Alloy service.                   | "alloy"                                                            |
-| `installation_dir`    | Directory where Grafana Alloy is to be installed.                    | "/etc/alloy"                                                      |
-| `environment_file`    | Name of the environment file for the Grafana Alloy service.          | "service.env"                                                      |
-| `config_dir`          | Directory for Grafana Alloy configuration.                           | "/etc/alloy"                                                      |
-| `config_file`         | Configuration file name for Grafana Alloy.                           | "config.river"                                                     |
-| `service_user`        | User under which the Grafana Alloy service will run.                 | "alloy"                                                            |
-| `service_group`       | Group under which the Grafana Alloy service will run.                | "alloy"                                                            |
-| `working_dir`         | Working directory for the Grafana Alloy service.                     | "/etc/alloy"                                                      |
-| `env_file_vars`       | Additional environment variables to be set in the service environment file. | {} (Empty dictionary)                                          |
-| `alloy_flags_extra`   | Extra flags to pass to the Alloy service.                            | {} (Empty dictionary)                                              |
-| `start_after_service` | Specify an optional dependency service Alloy should start after.     | '' (Empty string)                                                  |
-| `config`              | Configuration template for Grafana Alloy.                            | Configuration script with Prometheus scrape and remote_write setup |
+| `grafana_alloy_version`             | The version of Grafana Alloy to be installed.                        | "1.0.0"                                                             |
+| `grafana_alloy_arch_mapping`        | A mapping of common architecture names to Grafana Alloy binaries.    | `{'x86_64': 'amd64', 'aarch64': 'arm64', 'armv7l': 'armhf', 'i386': 'i386', 'ppc64le': 'ppc64le'}` |
+| `grafana_alloy_arch`                | The architecture of the current machine.                             | Based on `ansible_architecture` lookup, defaults to 'amd64'.       |
+| `grafana_alloy_binary_url`          | URL to Grafana Alloy binary for the specific version and architecture. | Constructed URL based on `version` and `arch` variables.          |
+| `grafana_alloy_service_name`        | The name to be used for the Grafana Alloy service.                   | "alloy"                                                            |
+| `grafana_alloy_installation_dir`    | Directory where Grafana Alloy is to be installed.                    | "/etc/alloy"                                                      |
+| `grafana_alloy_environment_file`    | Name of the environment file for the Grafana Alloy service.          | "service.env"                                                      |
+| `grafana_alloy_config_dir`          | Directory for Grafana Alloy configuration.                           | "/etc/alloy"                                                      |
+| `grafana_alloy_config_file`         | Configuration file name for Grafana Alloy.                           | "config.river"                                                     |
+| `grafana_alloy_service_user`        | User under which the Grafana Alloy service will run.                 | "alloy"                                                            |
+| `grafana_alloy_service_group`       | Group under which the Grafana Alloy service will run.                | "alloy"                                                            |
+| `grafana_alloy_working_dir`         | Working directory for the Grafana Alloy service.                     | "/etc/alloy"                                                      |
+| `grafana_alloy_env_file_vars`       | Additional environment variables to be set in the service environment file. | {} (Empty dictionary)                                          |
+| `grafana_alloy_flags_extra`   | Extra flags to pass to the Alloy service.                            | {} (Empty dictionary)                                              |
+| `grafana_alloy_start_after_service` | Specify an optional dependency service Alloy should start after.     | '' (Empty string)                                                  |
+| `grafana_alloy_config`              | Configuration template for Grafana Alloy.                            | Configuration script with Prometheus scrape and remote_write setup |
 
 
 ## Example Playbook
@@ -45,7 +45,7 @@ Including an example of how to use your role:
       ansible.builtin.include_role:
         name: grafana.grafana.alloy
       vars:
-        config: |
+        grafana_alloy_config: |
           prometheus.scrape "default" {
             targets = [{"__address__" = "localhost:12345"}]
             forward_to = [prometheus.remote_write.prom.receiver]

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -1,39 +1,39 @@
-version: "1.0.0"
+grafana_alloy_version: "1.0.0"
 
-arch_mapping:
+grafana_alloy_arch_mapping:
   x86_64: amd64
   aarch64: arm64
   armv7l: armhf
   i386: i386
   ppc64le: ppc64le
 
-arch: "{{ arch_mapping[ansible_architecture] | default('amd64') }}"
+grafana_alloy_arch: "{{ arch_mapping[ansible_architecture] | default('amd64') }}"
 
-binary_url: "https://github.com/grafana/alloy/releases/download/v{{ version }}/alloy-linux-{{ arch }}.zip"
+grafana_alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{{ version }}/alloy-linux-{{ arch }}.zip"
 
-service_name: "alloy"
+grafana_alloy_service_name: "alloy"
 
-installation_dir: "/etc/alloy"
+grafana_alloy_installation_dir: "/etc/alloy"
 
-environment_file: "service.env"
+grafana_alloy_environment_file: "service.env"
 
-config_dir: "/etc/alloy"
+grafana_alloy_config_dir: "/etc/alloy"
 
-config_file: "config.alloy"
+grafana_alloy_config_file: "config.alloy"
 
-service_user: "alloy"
+grafana_alloy_service_user: "alloy"
 
-service_group: "alloy"
+grafana_alloy_service_group: "alloy"
 
-working_dir: "/etc/alloy"
+grafana_alloy_working_dir: "/etc/alloy"
 
-env_file_vars: {}
+grafana_alloy_env_file_vars: {}
 
-alloy_flags_extra: {}
+grafana_alloy_flags_extra: {}
 
-start_after_service: ''
+grafana_alloy_start_after_service: ''
 
-config: |
+grafana_alloy_config: |
   prometheus.scrape "default" {
       targets = [{"__address__" = "localhost:12345"}]
       forward_to = [prometheus.remote_write.prom.receiver]

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -7,7 +7,7 @@ grafana_alloy_arch_mapping:
   i386: i386
   ppc64le: ppc64le
 
-grafana_alloy_arch: "{{ arch_mapping[ansible_architecture] | default('amd64') }}"
+grafana_alloy_arch: "{{ grafnana_alloy_arch_mapping[ansible_architecture] | default('amd64') }}"
 
 grafana_alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{{ grafana_alloy_version }}/alloy-linux-{{ grafana_alloy_arch }}.zip"
 

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -9,7 +9,7 @@ grafana_alloy_arch_mapping:
 
 grafana_alloy_arch: "{{ arch_mapping[ansible_architecture] | default('amd64') }}"
 
-grafana_alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{{ version }}/alloy-linux-{{ arch }}.zip"
+grafana_alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{{ grafana_allot_version }}/alloy-linux-{{ grafana_alloy_arch }}.zip"
 
 grafana_alloy_service_name: "alloy"
 

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -9,7 +9,7 @@ grafana_alloy_arch_mapping:
 
 grafana_alloy_arch: "{{ arch_mapping[ansible_architecture] | default('amd64') }}"
 
-grafana_alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{{ grafana_allot_version }}/alloy-linux-{{ grafana_alloy_arch }}.zip"
+grafana_alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{{ grafana_alloy_version }}/alloy-linux-{{ grafana_alloy_arch }}.zip"
 
 grafana_alloy_service_name: "alloy"
 

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -13,7 +13,9 @@ grafana_alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{
 
 grafana_alloy_service_name: "alloy"
 
-grafana_alloy_installation_dir: "/etc/alloy/bin"
+grafana_alloy_working_dir: "/opt/alloy"
+
+grafana_alloy_installation_dir: "{{ grafana_alloy_working_dir }}/bin"
 
 grafana_alloy_environment_file: "service.env"
 
@@ -24,8 +26,6 @@ grafana_alloy_config_file: "config.alloy"
 grafana_alloy_service_user: "alloy"
 
 grafana_alloy_service_group: "alloy"
-
-grafana_alloy_working_dir: "/etc/alloy"
 
 grafana_alloy_env_file_vars: {}
 

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -13,7 +13,7 @@ grafana_alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{
 
 grafana_alloy_service_name: "alloy"
 
-grafana_alloy_installation_dir: "/etc/alloy"
+grafana_alloy_installation_dir: "/etc/alloy/bin"
 
 grafana_alloy_environment_file: "service.env"
 

--- a/roles/alloy/handlers/main.yml
+++ b/roles/alloy/handlers/main.yml
@@ -1,5 +1,5 @@
 - name: Restart alloy
   ansible.builtin.systemd:
-    name: "{{ service_name }}"
+    name: "{{ grafana_alloy_service_name }}"
     state: restarted
   become: true

--- a/roles/alloy/tasks/configure.yml
+++ b/roles/alloy/tasks/configure.yml
@@ -1,18 +1,18 @@
 - name: Create alloy config directory
   ansible.builtin.file:
-    path: "{{ config_dir }}"
+    path: "{{ grafana_alloy_config_dir }}"
     state: directory
-    owner: "{{ service_user }}"
-    group: "{{ service_group }}"
+    owner: "{{ grafana_alloy_service_user }}"
+    group: "{{ grafana_alloy_service_group }}"
     mode: '0755'
   become: true
 
 - name: Deploy alloy configuration file
   ansible.builtin.template:
     src: config.alloy.j2
-    dest: "{{ config_dir }}/{{ config_file }}"
-    owner: "{{ service_user }}"
-    group: "{{ service_group }}"
+    dest: "{{ grafana_alloy_config_dir }}/{{ grafana_alloy_config_file }}"
+    owner: "{{ grafana_alloy_service_user }}"
+    group: "{{ grafana_alloy_service_group }}"
     mode: '0644'
   notify: Restart alloy
   become: true
@@ -20,9 +20,9 @@
 - name: Deploy alloy environment file
   ansible.builtin.template:
     src: environment.j2
-    dest: "{{ config_dir }}/{{ environment_file }}"
-    owner: "{{ service_user }}"
-    group: "{{ service_group }}"
+    dest: "{{ grafana_alloy_config_dir }}/{{ grafana_alloy_environment_file }}"
+    owner: "{{ grafana_alloy_service_user }}"
+    group: "{{ grafana_alloy_service_group }}"
     mode: '0644'
   notify: Restart alloy
   become: true

--- a/roles/alloy/tasks/install.yml
+++ b/roles/alloy/tasks/install.yml
@@ -33,6 +33,15 @@
   become: true
   when: grafana_alloy_download_result.changed
 
+- name: Create alloy working directory
+  ansible.builtin.file:
+    path: "{{ grafana_alloy_working_dir }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ grafana_alloy_service_user }}"
+    group: "{{ grafana_alloy_service_group }}"
+  become: true
+
 - name: Create alloy installation directory
   ansible.builtin.file:
     path: "{{ grafana_alloy_installation_dir }}"

--- a/roles/alloy/tasks/install.yml
+++ b/roles/alloy/tasks/install.yml
@@ -6,46 +6,46 @@
 
 - name: Create alloy group
   ansible.builtin.group:
-    name: "{{ service_group }}"
+    name: "{{ grafana_alloy_service_group }}"
     system: true
   become: true
 
 - name: Create alloy user
   ansible.builtin.user:
-    name: "{{ service_user }}"
-    group: "{{ service_group }}"
+    name: "{{ grafana_alloy_service_user }}"
+    group: "{{ grafana_alloy_service_group }}"
     system: true
     create_home: false  # Appropriate for a system user, usually doesn't need a home directory
   become: true
 
 - name: Download alloy binary
   ansible.builtin.get_url:
-    url: "{{ binary_url }}"
-    dest: "/tmp/alloy-{{ version }}.zip"
+    url: "{{ grafana_alloy_binary_url }}"
+    dest: "/tmp/alloy-{{ grafana_alloy_version }}.zip"
     mode: '0755'
   become: true
-  register: download_result
+  register: grafana_alloy_download_result
 
 - name: Remove existing alloy installation directory
   ansible.builtin.file:
-    path: "{{ installation_dir }}"
+    path: "{{ grafana_alloy_installation_dir }}"
     state: absent
   become: true
-  when: download_result.changed
+  when: grafana_alloy_download_result.changed
 
 - name: Create alloy installation directory
   ansible.builtin.file:
-    path: "{{ installation_dir }}"
+    path: "{{ grafana_alloy_installation_dir }}"
     state: directory
     mode: '0755'
-    owner: "{{ service_user }}"
-    group: "{{ service_group }}"
+    owner: "{{ grafana_alloy_service_user }}"
+    group: "{{ grafana_alloy_service_group }}"
   become: true
 
 - name: Extract alloy binary
   ansible.builtin.unarchive:
-    src: "/tmp/alloy-{{ version }}.zip"
-    dest: "{{ installation_dir }}"
+    src: "/tmp/alloy-{{ grafana_alloy_version }}.zip"
+    dest: "{{ grafana_alloy_installation_dir }}"
     remote_src: yes
   become: true
   register: extract_result

--- a/roles/alloy/tasks/service.yml
+++ b/roles/alloy/tasks/service.yml
@@ -1,7 +1,7 @@
 - name: Copy alloy systemd unit file
   ansible.builtin.template:
     src: alloy.service.j2
-    dest: /etc/systemd/system/{{ service_name }}.service
+    dest: /etc/systemd/system/{{ grafana_alloy_service_name }}.service
     mode: '0644'
   become: true
   notify: Restart alloy
@@ -13,7 +13,7 @@
 
 - name: Ensure alloy service is enabled and running
   ansible.builtin.service:
-    name: "{{ service_name }}"
+    name: "{{ grafana_alloy_service_name }}"
     enabled: yes
     state: started
   become: true

--- a/roles/alloy/templates/alloy.service.j2
+++ b/roles/alloy/templates/alloy.service.j2
@@ -6,13 +6,13 @@ After=network-online.target{{ ' ' + start_after_service if start_after_service i
 
 [Service]
 Restart=always
-User={{ service_user }}
-Group={{ service_group }}
+User={{ grafana_alloy_service_user }}
+Group={{ grafana_alloy_service_group }}
 Environment=HOSTNAME=%H
-EnvironmentFile={{ installation_dir }}/{{ environment_file }}
-WorkingDirectory={{ working_dir }}
-ExecStart={{ installation_dir }}/alloy-linux-{{ arch }} run \
-{% for flag, flag_value in alloy_flags_extra.items() %}
+EnvironmentFile={{ grafana_alloy_installation_dir }}/{{ grafana_alloy_environment_file }}
+WorkingDirectory={{ grafana_alloy_working_dir }}
+ExecStart={{ grafana_alloy_installation_dir }}/alloy-linux-{{ grafana_alloy_arch }} run \
+{% for flag, flag_value in grafana_alloy_flags_extra.items() %}
 {% if not flag_value %}
   --{{ flag }} \
 {% elif flag_value is string %}
@@ -23,7 +23,7 @@ ExecStart={{ installation_dir }}/alloy-linux-{{ arch }} run \
 {% endfor %}
 {% endif %}
 {% endfor %}
-    $CUSTOM_ARGS --storage.path={{ working_dir }} $CONFIG_FILE
+    $CUSTOM_ARGS --storage.path={{ grafana_alloy_working_dir }} $CONFIG_FILE
 ExecReload=/usr/bin/env kill -HUP $MAINPID
 TimeoutStopSec=20s
 SendSIGKILL=no

--- a/roles/alloy/templates/alloy.service.j2
+++ b/roles/alloy/templates/alloy.service.j2
@@ -9,7 +9,7 @@ Restart=always
 User={{ grafana_alloy_service_user }}
 Group={{ grafana_alloy_service_group }}
 Environment=HOSTNAME=%H
-EnvironmentFile={{ grafana_alloy_installation_dir }}/{{ grafana_alloy_environment_file }}
+EnvironmentFile={{ grafana_alloy_config_dir }}/{{ grafana_alloy_environment_file }}
 WorkingDirectory={{ grafana_alloy_working_dir }}
 ExecStart={{ grafana_alloy_installation_dir }}/alloy-linux-{{ grafana_alloy_arch }} run \
 {% for flag, flag_value in grafana_alloy_flags_extra.items() %}

--- a/roles/alloy/templates/config.alloy.j2
+++ b/roles/alloy/templates/config.alloy.j2
@@ -1,1 +1,1 @@
-{{ config }}
+{{ grafana_alloy_config }}

--- a/roles/alloy/templates/environment.j2
+++ b/roles/alloy/templates/environment.j2
@@ -1,10 +1,10 @@
 {{ ansible_managed | comment }}
 # Grafana Alloy Environment File
-CONFIG_FILE="{{ config_dir }}/{{ config_file }}"
+CONFIG_FILE="{{ grafana_alloy_config_dir }}/{{ grafana_alloy_config_file }}"
 
 GOMAXPROCS={{ ansible_processor_vcpus|default(ansible_processor_count) }}
 RESTART_ON_UPGRADE=true
 
-{% for key, value in env_file_vars.items() %}
+{% for key, value in grafana_alloy_env_file_vars.items() %}
 {{key}}={{value}}
 {% endfor %}


### PR DESCRIPTION
This should address #206 and #194

This PR should make sure the Alloy variables are unique and won't clash with other variables (like `version`) used elsewhere in playbooks.

It also moves the binary and working directory out of `/etc` where RHEL and SELinux get upset about.