### PR TITLE
Fix Grafana Configuration for Unified and Legacy Alerting Based on Version

### DIFF
--- a/roles/grafana/README.md
+++ b/roles/grafana/README.md
@@ -50,7 +50,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_session` | {} | [session](http://docs.grafana.org/installation/configuration/#session) management configuration section |
 | `grafana_analytics` | {} | Google [analytics](http://docs.grafana.org/installation/configuration/#analytics) configuration section |
 | `grafana_smtp` | {} | [smtp](http://docs.grafana.org/installation/configuration/#smtp) configuration section |
-| `grafana_alerting` | {} | [alerting](http://docs.grafana.org/installation/configuration/#alerting) configuration section |
+| `grafana_alerting` | {} | [alerting](http://docs.grafana.org/installation/configuration/#alerting) configuration section, require Grafana v10 and below |
+| `grafana_unified_alerting` | {} | [unified_alerting](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#unified_alerting) configuration section, require Grafana v11+ |
 | `grafana_log` | {} | [log](http://docs.grafana.org/installation/configuration/#log) configuration section |
 | `grafana_metrics` | {} | [metrics](http://docs.grafana.org/installation/configuration/#metrics) configuration section |
 | `grafana_tracing` | {} | [tracing](http://docs.grafana.org/installation/configuration/#tracing) configuration section |

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -175,7 +175,12 @@ grafana_smtp: {}
 #  password:
 #  from_address:
 
-# Enable grafana alerting mechanism
+# Enable grafana unified alerting mechanism for grafana v11+
+grafana_unified_alerting:
+  enabled: true
+
+# REMOVED FROM Grafana v11+
+# Enable grafana alerting mechanism for grafana v10 and below
 grafana_alerting:
   execute_alerts: true
 #  error_or_timeout: 'alerting'

--- a/roles/grafana/templates/grafana.ini.j2
+++ b/roles/grafana/templates/grafana.ini.j2
@@ -113,6 +113,19 @@ versions_to_keep = 20
 enabled = true
 path = {{ grafana_data_dir }}/dashboards
 
+{% if grafana_version == 'latest' or grafana_version.split('.')[0]|int >= 11 %}
+# Unified Alerting
+[unified_alerting]
+{% if grafana_unified_alerting != {} %}
+{%   for k,v in grafana_unified_alerting.items() %}
+{{ k }} = {{ v }}
+{%   endfor %}
+{% else %}
+enabled = false
+{% endif %}
+{% endif %}
+
+{% if grafana_version != 'latest' and grafana_version.split('.')[0]|int < 11 %}
 # Alerting
 [alerting]
 {% if grafana_alerting != {} %}
@@ -124,6 +137,7 @@ enabled = true
 {%   endfor %}
 {% else %}
 enabled = false
+{% endif %}
 {% endif %}
 
 # SMTP and email config


### PR DESCRIPTION
## Summary

This PR addresses an issue where the `[alerting]` section was incorrectly templated for Grafana versions `v11` and higher, causing failures in Grafana deployments.

## Changes

- Updated the Jinja template for Grafana configuration to conditionally include `[unified_alerting]` and `[alerting]` sections based on the Grafana version.
  - The `[unified_alerting]` section is included when `grafana_version` is `latest` or `v11` and higher.
  - The `[alerting]` section is included only for versions below `v11`.

## Testing

- Verified that the `[unified_alerting]` section is correctly templated for versions `latest` and `v11+`.
- Verified that the `[alerting]` section is correctly templated for versions below `v11`.

## Notes

- This change ensures compatibility with the unified alerting mechanism introduced in Grafana `v11` and maintains support for legacy alerting mechanisms in older versions.
- This fixes https://github.com/grafana/grafana-ansible-collection/pull/203 which was not progressed.
- This fixes https://github.com/grafana/grafana-ansible-collection/issues/204 which reported this problem in the Grafana role.