### PR TITLE
Set alerting to empty dict to ensure it is disabled by default

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -176,8 +176,8 @@ grafana_smtp: {}
 #  from_address:
 
 # Enable grafana alerting mechanism
-grafana_alerting:
-  execute_alerts: true
+grafana_alerting: {}
+#  execute_alerts: true
 #  error_or_timeout: 'alerting'
 #  nodata_or_nullvalues: 'no_data'
 #  concurrent_render_limit: 5


### PR DESCRIPTION
Fix #220

If we set the variable `grafana_alerting` to `{}`, the `alerting .enabled` would be set to `false`.

https://github.com/grafana/grafana-ansible-collection/blob/2e7fd0591d8ad1700186174213b8142047525b88/roles/grafana/templates/grafana.ini.j2#L116-L127

It is suggested as below.
> Confirm that you don’t intend to upgrade your legacy alerts by [disabling legacy alerting](https://grafana.com/docs/grafana/v10.4/alerting/set-up/migrating-alerts/#enable-grafana-alerting) (optionally enable Grafana Alerting) in your configuration file.


BTW, keep it is the same as README, https://github.com/grafana/grafana-ansible-collection/blob/2e7fd0591d8ad1700186174213b8142047525b88/roles/grafana/README.md?plain=1#L53

Reference:

https://grafana.com/docs/grafana/v10.4/alerting/set-up/migrating-alerts/#what-happens-if-i-dont-upgrade-from-legacy-alerting-to-grafana-alerting-before-installing-grafana-11