### PR TITLE
Prefix default variables

### DIFF
--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -1,4 +1,4 @@
-version: "1.0.0"
+alloy_version: "1.1.1"
 
 arch_mapping:
   x86_64: amd64
@@ -7,33 +7,33 @@ arch_mapping:
   i386: i386
   ppc64le: ppc64le
 
-arch: "{{ arch_mapping[ansible_architecture] | default('amd64') }}"
+__alloy_arch: "{{ arch_mapping[ansible_architecture] | default('amd64') }}"
 
-binary_url: "https://github.com/grafana/alloy/releases/download/v{{ version }}/alloy-linux-{{ arch }}.zip"
+alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{{ version }}/alloy-linux-{{ __alloy_arch }}.zip"
 
-service_name: "alloy"
+alloy_service_name: "alloy"
 
-installation_dir: "/usr/local/bin"
+alloy_installation_dir: "/usr/local/bin"
 
-environment_file: "service.env"
+alloy_environment_file: "service.env"
 
-config_dir: "/etc/alloy"
+alloy_config_dir: "/etc/alloy"
 
-config_file: "config.alloy"
+alloy_config_file: "config.alloy"
 
-service_user: "alloy"
+alloy_service_user: "alloy"
 
-service_group: "alloy"
+alloy_service_group: "alloy"
 
-working_dir: "/var/lib/alloy"
+alloy_working_dir: "/var/lib/alloy"
 
-env_file_vars: {}
+alloy_env_file_vars: {}
 
 alloy_flags_extra: {}
 
-start_after_service: ''
+alloy_start_after_service: ''
 
-config: |
+alloy_config: |
   prometheus.scrape "default" {
       targets = [{"__address__" = "localhost:12345"}]
       forward_to = [prometheus.remote_write.prom.receiver]

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -9,7 +9,7 @@ arch_mapping:
 
 __alloy_arch: "{{ arch_mapping[ansible_architecture] | default('amd64') }}"
 
-alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{{ version }}/alloy-linux-{{ __alloy_arch }}.zip"
+alloy_binary_url: "https://github.com/grafana/alloy/releases/download/v{{ alloy_version }}/alloy-linux-{{ __alloy_arch }}.zip"
 
 alloy_service_name: "alloy"
 

--- a/roles/alloy/handlers/main.yml
+++ b/roles/alloy/handlers/main.yml
@@ -1,6 +1,6 @@
 - name: Restart alloy
   ansible.builtin.systemd:
-    name: "{{ service_name }}"
+    name: "{{ alloy_service_name }}"
     state: restarted
   become: true
   listen: "Restart alloy"

--- a/roles/alloy/tasks/configure.yml
+++ b/roles/alloy/tasks/configure.yml
@@ -1,27 +1,27 @@
 - name: Create alloy working directory
   ansible.builtin.file:
-    path: "{{ working_dir }}"
+    path: "{{ alloy_working_dir }}"
     state: directory
-    owner: "{{ service_user }}"
-    group: "{{ service_group }}"
+    owner: "{{ alloy_service_user }}"
+    group: "{{ alloy_service_group }}"
     mode: "0755"
   become: true
 
 - name: Create alloy config directory
   ansible.builtin.file:
-    path: "{{ config_dir }}"
+    path: "{{ alloy_config_dir }}"
     state: directory
-    owner: "{{ service_user }}"
-    group: "{{ service_group }}"
+    owner: "{{ alloy_service_user }}"
+    group: "{{ alloy_service_group }}"
     mode: '0755'
   become: true
 
 - name: Deploy alloy configuration file
   ansible.builtin.template:
     src: config.alloy.j2
-    dest: "{{ config_dir }}/{{ config_file }}"
-    owner: "{{ service_user }}"
-    group: "{{ service_group }}"
+    dest: "{{ alloy_config_dir }}/{{ alloy_config_file }}"
+    owner: "{{ alloy_service_user }}"
+    group: "{{ alloy_service_group }}"
     mode: '0644'
   notify: Restart alloy
   become: true
@@ -29,9 +29,9 @@
 - name: Deploy alloy environment file
   ansible.builtin.template:
     src: environment.j2
-    dest: "{{ config_dir }}/{{ environment_file }}"
-    owner: "{{ service_user }}"
-    group: "{{ service_group }}"
+    dest: "{{ alloy_config_dir }}/{{ alloy_environment_file }}"
+    owner: "{{ alloy_service_user }}"
+    group: "{{ alloy_service_group }}"
     mode: '0644'
   notify: Restart alloy
   become: true

--- a/roles/alloy/tasks/ga-started.yml
+++ b/roles/alloy/tasks/ga-started.yml
@@ -17,7 +17,7 @@
   block:
     - name: Run journalctl
       ansible.builtin.shell:
-        cmd: "journalctl -u {{ service_name }} -b -n20 --no-pager"
+        cmd: "journalctl -u {{ alloy_service_name }} -b -n20 --no-pager"
       register: journal_ret
       changed_when: false
     - name: Output Grafana Alloy logs
@@ -26,4 +26,4 @@
     - name: Raise alerts
       ansible.builtin.assert:
         that: false
-        fail_msg: "Service {{ service_name }} hasn't started."
+        fail_msg: "Service {{ alloy_service_name }} hasn't started."

--- a/roles/alloy/tasks/install.yml
+++ b/roles/alloy/tasks/install.yml
@@ -6,37 +6,37 @@
 
 - name: Create alloy group
   ansible.builtin.group:
-    name: "{{ service_group }}"
+    name: "{{ alloy_service_group }}"
     system: true
   become: true
 
 - name: Create alloy user
   ansible.builtin.user:
-    name: "{{ service_user }}"
-    groups: "{{ [ service_group ] + alloy_user_groups }}"
+    name: "{{ alloy_service_user }}"
+    groups: "{{ [ alloy_service_group ] + alloy_user_groups }}"
     system: true
     create_home: false  # Appropriate for a system user, usually doesn't need a home directory
   become: true
 
 - name: Download alloy binary
   ansible.builtin.get_url:
-    url: "{{ binary_url }}"
-    dest: "/tmp/alloy-{{ version }}.zip"
+    url: "{{ alloy_binary_url }}"
+    dest: "/tmp/alloy-{{ alloy_version }}.zip"
     mode: '0755'
   become: true
   register: download_result
 
 - name: Remove existing alloy binary
   ansible.builtin.file:
-    path: "{{ installation_dir }}/alloy-linux-{{ arch }}"
+    path: "{{ alloy_installation_dir }}/alloy-linux-{{ __alloy_arch }}"
     state: absent
   become: true
   when: download_result.changed
 
 - name: Extract alloy binary
   ansible.builtin.unarchive:
-    src: "/tmp/alloy-{{ version }}.zip"
-    dest: "{{ installation_dir }}"
+    src: "/tmp/alloy-{{ alloy_version }}.zip"
+    dest: "{{ alloy_installation_dir }}"
     remote_src: yes
   become: true
   register: extract_result

--- a/roles/alloy/tasks/service.yml
+++ b/roles/alloy/tasks/service.yml
@@ -1,7 +1,7 @@
 - name: Copy alloy systemd unit file
   ansible.builtin.template:
     src: alloy.service.j2
-    dest: /etc/systemd/system/{{ service_name }}.service
+    dest: /etc/systemd/system/{{ alloy_service_name }}.service
     mode: "0644"
   become: true
   notify: Restart alloy
@@ -16,7 +16,7 @@
 
 - name: Ensure alloy service is enabled and running
   ansible.builtin.service:
-    name: "{{ service_name }}"
+    name: "{{ alloy_service_name }}"
     enabled: yes
     state: started
   become: true

--- a/roles/alloy/templates/alloy.service.j2
+++ b/roles/alloy/templates/alloy.service.j2
@@ -6,12 +6,12 @@ After=network-online.target{{ ' ' + start_after_service if start_after_service i
 
 [Service]
 Restart=always
-User={{ service_user }}
-Group={{ service_group }}
+User={{ alloy_service_user }}
+Group={{ alloy_service_group }}
 Environment=HOSTNAME=%H
-EnvironmentFile={{ config_dir }}/{{ environment_file }}
-WorkingDirectory={{ working_dir }}
-ExecStart={{ installation_dir }}/alloy-linux-{{ arch }} run \
+EnvironmentFile={{ alloy_config_dir }}/{{ alloy_environment_file }}
+WorkingDirectory={{ alloy_working_dir }}
+ExecStart={{ alloy_installation_dir }}/alloy-linux-{{ __alloy_arch }} run \
 {% for flag, flag_value in alloy_flags_extra.items() %}
 {% if not flag_value %}
   --{{ flag }} \
@@ -23,7 +23,7 @@ ExecStart={{ installation_dir }}/alloy-linux-{{ arch }} run \
 {% endfor %}
 {% endif %}
 {% endfor %}
-    $CUSTOM_ARGS --storage.path={{ working_dir }} $CONFIG_FILE
+    $CUSTOM_ARGS --storage.path={{ alloy_working_dir }} $CONFIG_FILE
 ExecReload=/usr/bin/env kill -HUP $MAINPID
 TimeoutStopSec=20s
 SendSIGKILL=no

--- a/roles/alloy/templates/config.alloy.j2
+++ b/roles/alloy/templates/config.alloy.j2
@@ -1,1 +1,1 @@
-{{ config }}
+{{ alloy_config }}

--- a/roles/alloy/templates/environment.j2
+++ b/roles/alloy/templates/environment.j2
@@ -1,6 +1,6 @@
 {{ ansible_managed | comment }}
 # Grafana Alloy Environment File
-CONFIG_FILE="{{ config_dir }}/{{ config_file }}"
+CONFIG_FILE="{{ alloy_config_dir }}/{{ alloy_config_file }}"
 
 GOMAXPROCS={{ ansible_processor_vcpus|default(ansible_processor_count) }}
 RESTART_ON_UPGRADE=true

--- a/roles/alloy/templates/environment.j2
+++ b/roles/alloy/templates/environment.j2
@@ -5,6 +5,6 @@ CONFIG_FILE="{{ alloy_config_dir }}/{{ alloy_config_file }}"
 GOMAXPROCS={{ ansible_processor_vcpus|default(ansible_processor_count) }}
 RESTART_ON_UPGRADE=true
 
-{% for key, value in env_file_vars.items() %}
+{% for key, value in alloy_env_file_vars.items() %}
 {{key}}={{value}}
 {% endfor %}


### PR DESCRIPTION
I'd like to propose to prefix Alloy default variables to allow users to have flexibility for playbooks that run against many groups and be able to change things at host level.

Current non-prefixed, collided also with some other common named variables that might be used.

This also aligns Alloy to all the other Grafana roles.