### PR TITLE
Adding "distributor" section support to mimir config file

### DIFF
--- a/roles/mimir/templates/config.yml.j2
+++ b/roles/mimir/templates/config.yml.j2
@@ -50,3 +50,8 @@ server:
 limits:
   {{ mimir_limits | to_nice_yaml(indent=2, sort_keys=False) | indent(2, False)}}
 {% endif %}
+
+{% if mimir_distributor is defined %}
+distributor:
+  {{ mimir_distributor | to_nice_yaml(indent=2, sort_keys=False) | indent(2, False)}}
+{% endif %}


### PR DESCRIPTION
Hello,

This small edit allows users to add distributor section to mimir config file.
The distributor section is mandatory for [Mimir high-availability deduplication](https://grafana.com/docs/mimir/latest/configure/configure-high-availability-deduplication/).
Here's an example : 
```
... 

limits:
  accept_ha_samples: true


distributor:
  ha_tracker:
    enable_ha_tracker: true
    kvstore:
      store: etcd
      etcd:
        tls_enabled: false
        endpoints:
        - 10.103.0.174:2379
        - 10.103.0.71:2379
```