### PR TITLE
Allow to include the Loki & Promtail roles with a tag

### DIFF
--- a/roles/loki/tasks/main.yml
+++ b/roles/loki/tasks/main.yml
@@ -17,7 +17,5 @@
     apply:
       tags:
         - loki_uninstall
-        - never
-  tags:
-    - loki_uninstall
-    - never
+  when: "'loki_uninstall' in ansible_run_tags"
+  tags: always

--- a/roles/loki/tasks/uninstall.yml
+++ b/roles/loki/tasks/uninstall.yml
@@ -29,7 +29,7 @@
     state: disabled
   ignore_errors: true
 
-- name: Remove Loki directories"
+- name: Remove Loki directories
   ansible.builtin.file:
     path: "{{ remove_me }}"
     state: absent

--- a/roles/promtail/tasks/main.yml
+++ b/roles/promtail/tasks/main.yml
@@ -18,6 +18,5 @@
       tags:
         - promtail_uninstall
         - never
-  tags:
-    - promtail_uninstall
-    - never
+  when: "'promtail_uninstall' in ansible_run_tags"
+  tags: always

--- a/roles/promtail/tasks/uninstall.yml
+++ b/roles/promtail/tasks/uninstall.yml
@@ -88,14 +88,14 @@
   when: ansible_os_family == 'Debian'
 
 - name: Ensure that Promtail firewalld rule is not present - tcp port {{ promtail_http_listen_port }}
-  ansible.posix.firewalld:  # noqa ignore-errors
+  ansible.posix.firewalld: # noqa ignore-errors
     immediate: true
     permanent: true
     port: "{{ promtail_http_listen_port }}/tcp"
     state: disabled
   ignore_errors: true
 
-- name: Remove Promtail directories"
+- name: Remove Promtail directories
   ansible.builtin.file:
     path: "{{ remove_me }}"
     state: absent


### PR DESCRIPTION
Allow to include the Loki & Promtail roles with a tag.

This modification does not introduce a breaking change and fix an issue when including those roles with a tag, in this case the `uninstall.yml` file is always executed.

## Versions

- ansible: `[core 2.16.5]`
- grafana-ansible-collection: `5.3.0`

## Tests

You can check those tests to understand, reproduce the observed behavior:

```yaml
# playbook-test.yml

- hosts: localhost
  connection: local
  roles:
    - { role: example, tags: loki }
```

```yaml
# example/tasks/main.yml

- name: Deploy Loki service
  ansible.builtin.debug:
    msg: Include deploy.yml
  tags: loki_deploy

- name: Uninstall Loki service (Current version)
  ansible.builtin.debug:
    msg: Include uninstall.yml
  tags: [never, loki_uninstall]

- name: Uninstall Loki service (New version)
  ansible.builtin.debug:
    msg: Include uninstall.yml
  when: "'loki_uninstall' in ansible_run_tags"
  tags: always
```

## Running without tags

When running the playbook without tag the uninstall action is not executed, everything works as expected.

``` console
$ ansible-playbook playbook-test.yml

PLAY [localhost] *******************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************
ok: [localhost]

TASK [example : Deploy Loki service] ***********************************************************************************
ok: [localhost] => {
    "msg": "Include deploy.yml"
}

TASK [example : Uninstall Loki service (New version)] ******************************************************************
skipping: [localhost]

PLAY RECAP *************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
```

## Running with the role's tag (defined in the playbook) 💥

This is the problematic use case because Loki is installed and uninstalled:

```console
$ ansible-playbook playbook-test.yml -t loki

PLAY [localhost] *******************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************
ok: [localhost]

TASK [example : Deploy Loki service] ***********************************************************************************
ok: [localhost] => {
    "msg": "Include deploy.yml"
}

TASK [example : Uninstall Loki service (Current version)] **************************************************************
ok: [localhost] => {
    "msg": "Include uninstall.yml"
}

TASK [example : Uninstall Loki service (New version)] ******************************************************************
skipping: [localhost]

PLAY RECAP *************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
```

But we can see that the new version works as expected, the task is skipped.

## Running with the uninstall tag (defined in the role)

The uninstall also works as expected:

```console
$ ansible-playbook playbook-test.yml -t loki_uninstall

PLAY [localhost] *******************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************
ok: [localhost]

TASK [example : Uninstall Loki service (Current version)] **************************************************************
ok: [localhost] => {
    "msg": "Include uninstall.yml"
}

TASK [example : Uninstall Loki service (New version)] ******************************************************************
ok: [localhost] => {
    "msg": "Include uninstall.yml"
}

PLAY RECAP *************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```