### PR TITLE
add grafana_plugins_ops to defaults and docs

### DIFF
--- a/roles/grafana/README.md
+++ b/roles/grafana/README.md
@@ -64,6 +64,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `grafana_datasources` | [] | List of datasources which should be configured |
 | `grafana_environment` | {} | Optional Environment param for Grafana installation, useful ie for setting http_proxy |
 | `grafana_plugins` | [] |  List of Grafana plugins which should be installed |
+| `grafana_plugins_ops` | {} |  [plugins](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#plugins-1) configuration section |
 | `grafana_alert_notifications` | [] | List of alert notification channels to be created, updated, or deleted |
 
 Data source example:

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -239,9 +239,14 @@ grafana_feature_toggles: {}
 #  regressionTransformation: true
 
 #######
-# Plugins from https://grafana.com/plugins
+# Plugins to install from https://grafana.com/plugins
 grafana_plugins: []
 #  - raintank-worldping-app
+
+#######
+# Configuration of plugins  ([plugin] section of grafana.ini]
+grafana_plugins_ops: {}
+#  allow_loading_unsigned_plugins: alexanderzobnin-zabbix-datasource
 
 # Dashboards from https://grafana.com/dashboards
 grafana_dashboards: []

--- a/roles/grafana/templates/grafana.ini.j2
+++ b/roles/grafana/templates/grafana.ini.j2
@@ -38,7 +38,7 @@ root_url = {{ grafana_url }}
 {% endfor %}
 
 # Plugins
-{% if grafana_plugins_ops is defined %}
+{% if grafana_plugins_ops != {} %}
 [plugins]
 {% for k,v in grafana_plugins_ops.items() %}
 {{ k }} = {{ v }}


### PR DESCRIPTION
A configuration variable `grafana_plugins_ops` has been added in https://github.com/grafana/grafana-ansible-collection/pull/88 PR (in `grafana.ini` template). This value wasn't however added to the documentation nor defaults which this PR attempts to rectify.

For. consistency with all other configuration sections I've changed the template slightly. In most cases it should have the identical result (section included when expected dictionary is not empty) but it *is* a subtle interface change. If preserving the exact behaviour is the key, changing the default value to `None` should do the trick.