### PR TITLE
fix: Loki avoid uninstall when importing the role with tags

### DIFF
--- a/roles/loki/README.md
+++ b/roles/loki/README.md
@@ -6,33 +6,40 @@ The Ansible Loki Role allows you to effortlessly deploy and manage [Loki](https:
 
 **🔑 Key Features**
 - **📦 Out-of-the-box Deployment**: Get Loki up and running quickly with default configurations.
-- **🧹 Effortless Uninstall**: Easily remove Loki from your system using the "loki_uninstall" tag.
-- **🔔 Example Alerting Rules**: Benefit from the included sample Ruler configuration. Utilize the provided example alerting rules as a reference guide for structuring your own rules effectively.
+-   **🧹 Effortless Uninstall**: Easily remove Loki from your system setting the "loki_uninstall" variable.
+-   **🔔 Example Alerting Rules**: Benefit from the included sample Ruler configuration. Utilize the provided example alerting rules as a reference guide for structuring your own rules effectively.
 
 ## Table of Content
 
-- [Requirements](#requirements)
-- [Role Variables](#role-variables)
-- - [Default Variables - `defaults/main.yml`](#default-variables---defaultsmainyml)
-- - [Alerting Rules Variables](#alerting-rules-variables)
-- - [Additional Config Variables for `/etc/loki/config.yml`](#additional-config-variables-for-etclokiconfigyml)
-- [Playbook](#playbook)
+-   [Requirements](#requirements)
+-   [Role Variables](#role-variables)
+-   -   [Default Variables - `defaults/main.yml`](#default-variables---defaultsmainyml)
+-   -   [Alerting Rules Variables](#alerting-rules-variables)
+-   -   [Additional Config Variables for `/etc/loki/config.yml`](#additional-config-variables-for-etclokiconfigyml)
+-   [Playbook](#playbook)
 
 ## Requirements
 
-- Ansible 2.10+
+-   Ansible 2.10+
 
 ## Role Variables
 
-- 📚 Official Loki configuration [documentation](https://grafana.com/docs/loki/latest/configuration/)
-- 🏗️ Upgrading Loki [documentation](https://grafana.com/docs/loki/latest/upgrading/)
+-   📚 Official Loki configuration [documentation](https://grafana.com/docs/loki/latest/configuration/)
+-   🏗️ Upgrading Loki [documentation](https://grafana.com/docs/loki/latest/upgrading/)
 
 ### **Default Variables - `defaults/main.yml`**
 
 ```yaml
 loki_version: "latest"
 ```
+
 The version of Loki to download and deploy. Supported standard version "3.0.0" format or "latest".
+
+```yaml
+loki_uninstall: "false"
+```
+
+If set to `true` will perfom uninstall instead of deployment.
 
 ```yaml
 loki_http_listen_port: 3100

--- a/roles/loki/defaults/main.yml
+++ b/roles/loki/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for loki
 loki_version: "latest"
+loki_uninstall: false
 loki_http_listen_port: 3100
 loki_http_listen_address: "0.0.0.0"
 loki_expose_port: false

--- a/roles/loki/tasks/main.yml
+++ b/roles/loki/tasks/main.yml
@@ -7,17 +7,9 @@
 - name: Deploy Loki service
   ansible.builtin.include_tasks:
     file: "deploy.yml"
-    apply:
-      tags: loki_deploy
-  tags: loki_deploy
+  when: not loki_uninstall
 
 - name: Uninstall Loki service
   ansible.builtin.include_tasks:
     file: "uninstall.yml"
-    apply:
-      tags:
-        - loki_uninstall
-        - never
-  tags:
-    - loki_uninstall
-    - never
+  when: loki_uninstall


### PR DESCRIPTION
When importing the "loki" role into a playbook via a task with `ansible.builtin.import_role` plus tags "loki"; and i call the playbook with the tag "loki", the uninstall sequence is executed.

This change replace the use of tags by explicitly setting the `uninstall_loki` variable.