### PR TITLE
fix:mimir molecule should use ansible core 2.16

### DIFF
--- a/.github/workflows/mimir-molecule.yml
+++ b/.github/workflows/mimir-molecule.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install molecule molecule-plugins[docker] docker pytest-testinfra jmespath selinux passlib
+        run: pip3 install ansible-core==2.16 'molecule-plugins[docker]' pytest-testinfra jmespath selinux passlib
 
       - name: create docker network
         run: docker network create molecule

--- a/roles/mimir/README.md
+++ b/roles/mimir/README.md
@@ -25,7 +25,7 @@ source .venv/bin/activate
 .\.venv\Scripts\activate
 
 # Install dependencies
-pip3 install molecule molecule-plugins[docker] docker pytest-testinfra jmespath selinux passlib
+pip3 install ansible-core==2.16 'molecule-plugins[docker]' pytest-testinfra jmespath selinux passlib
 
 # Create molecule network
 docker network create molecule

--- a/roles/mimir/molecule/test-requirements.txt
+++ b/roles/mimir/molecule/test-requirements.txt
@@ -1,6 +1,0 @@
-molecule
-docker
-pytest-testinfra
-jmespath
-selinux
-passlib


### PR DESCRIPTION
Mimir tests are failing due to an Python issue. Based on discussions here: https://github.com/geerlingguy/docker-rockylinux8-ansible/issues/6, I decided to update the tests.