### PR TITLE
fix: message argument of dashboard task

### DIFF
--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -72,7 +72,7 @@
     grafana_user: "{{ grafana_security.admin_user }}"
     grafana_password: "{{ grafana_security.admin_password }}"
     path: "{{ item }}"
-    message: "Updated by ansible role {{ ansible_role_name }}"
+    commit_message: "Updated by ansible role {{ ansible_role_name }}"
     state: present
     overwrite: true
   no_log: "{{ 'false' if lookup('env', 'CI') else 'true' }}"


### PR DESCRIPTION
removed deprecated argument `message` in favor of `commit_message` in release [v2.0.0](https://github.com/ansible-collections/community.grafana/releases/tag/2.0.0)
https://github.com/ansible-collections/community.grafana/pull/372