### PR TITLE
fix: Updated promtail arch map for aarch64 matching

### DIFF
--- a/roles/loki/vars/Debian.yml
+++ b/roles/loki/vars/Debian.yml
@@ -1,5 +1,8 @@
 ---
 __loki_arch_map:
   x86_64: 'amd64'
+  armv6l: 'arm'
+  armv7l: 'arm'
+  aarch64: 'arm64'
 
 __loki_arch: "{{ __loki_arch_map[ansible_architecture] | default(ansible_architecture) }}"

--- a/roles/promtail/vars/Debian.yml
+++ b/roles/promtail/vars/Debian.yml
@@ -1,5 +1,8 @@
 ---
 __promtail_arch_map:
-  x86_64: 'amd64'
+  x86_64: amd64
+  armv6l: arm
+  armv7l: arm
+  aarch64: arm64
 
 __promtail_arch: "{{ __promtail_arch_map[ansible_architecture] | default(ansible_architecture) }}"

--- a/roles/promtail/vars/Debian.yml
+++ b/roles/promtail/vars/Debian.yml
@@ -1,8 +1,8 @@
 ---
 __promtail_arch_map:
-  x86_64: amd64
-  armv6l: arm
-  armv7l: arm
-  aarch64: arm64
+  x86_64: 'amd64'
+  armv6l: 'arm'
+  armv7l: 'arm'
+  aarch64: 'arm64'
 
 __promtail_arch: "{{ __promtail_arch_map[ansible_architecture] | default(ansible_architecture) }}"


### PR DESCRIPTION
Hi, I've used the collection to install promtail on a couple of Arm64 vms and I found that the machine architecture for the promtail installation is not mapped to arm64, to permit matching on the file to download.
The role tried to download the file with suffix `aarch64` but the correct one is `arm64`, so I committed the updated promtail architecture map, also including 2 variations for old Raspberrys

```yaml
__promtail_arch_map:
  x86_64: amd64
  armv6l: arm
  armv7l: arm
  aarch64: arm64
``` 