### PR TITLE
fix: disable alerting in the Grafana role

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -181,8 +181,8 @@ grafana_unified_alerting:
 
 # REMOVED FROM Grafana v11+
 # Enable grafana alerting mechanism for grafana v10 and below
-grafana_alerting:
-  execute_alerts: true
+grafana_alerting: {}
+#  execute_alerts: true
 #  error_or_timeout: 'alerting'
 #  nodata_or_nullvalues: 'no_data'
 #  concurrent_render_limit: 5


### PR DESCRIPTION
Since this functionality is removed from the Grafana v11, if somebody uses the playbook to configure that Grafana version, the playbook will fail, because the variable is defined and enables the alerting option. Let's change this behavior and make it ready for Grafana v11+.