### PR TITLE
promtail: add support for extra args

### DIFF
--- a/roles/promtail/README.md
+++ b/roles/promtail/README.md
@@ -62,6 +62,11 @@ By default, Promtail runs in root-less mode. It supports two modes:
 - `root`: Root mode, where Promtail runs as root and ACL configuration is skipped.
 
 ```yaml
+promtail_extra_flags: []
+```
+Additional flags to be passed to the Promtail systemd unit.
+
+```yaml
 promtail_user_append_groups:
   - "systemd-journal"
 ```

--- a/roles/promtail/defaults/main.yml
+++ b/roles/promtail/defaults/main.yml
@@ -7,6 +7,10 @@ promtail_http_listen_address: "0.0.0.0"
 promtail_expose_port: false
 promtail_positions_path: "/var/lib/promtail"
 promtail_runtime_mode: "acl"  # Supported "root" or "acl"
+promtail_extra_flags: []
+# promtail_extra_flags:
+#   - "-server.enable-runtime-reload"
+#   - "-config.expand-env=true"
 
 promtail_user_append_groups:
   - "systemd-journal"

--- a/roles/promtail/tasks/deploy.yml
+++ b/roles/promtail/tasks/deploy.yml
@@ -58,7 +58,7 @@
     owner: "promtail"
     group: "root"
     mode: "0644"
-    validate: "/usr/bin/promtail -check-syntax -config.file %s"
+    validate: "/usr/bin/promtail -config.expand-env=true -check-syntax -config.file %s"
   notify: restart promtail
 
 - name: Template Promtail systemd - /etc/systemd/system/promtail.service

--- a/roles/promtail/templates/promtail.service.j2
+++ b/roles/promtail/templates/promtail.service.j2
@@ -9,7 +9,13 @@ User=promtail
 {% elif promtail_runtime_mode == "root" %}
 User=root
 {% endif %}
-ExecStart=/usr/bin/promtail -config.file /etc/promtail/config.yml
+ExecStart=/usr/bin/promtail \
+{% if promtail_extra_flags | length > 0 %}
+{% for flag in promtail_extra_flags %}
+  {{ flag }} \
+{% endfor %}
+{% endif %}
+  -config.file /etc/promtail/config.yml
 
 TimeoutSec = 60
 Restart = on-failure


### PR DESCRIPTION
Currently, there is no way to set any additional Promtail arguments/flags, such as `-server.enable-runtime-reload` and `-config.expand-env=true`, outside of those configured as role variables.

Adds the ability to pass additional arguments/flags to each call of the Promtail binary.