### PR TITLE
Add check_mode: false to Loki "Scrape GitHub" Task

### DIFF
--- a/roles/loki/tasks/deploy.yml
+++ b/roles/loki/tasks/deploy.yml
@@ -12,6 +12,7 @@
       become: false
       delegate_to: localhost
       run_once: true
+      check_mode: false
       register: __github_latest_version
 
     - name: Latest available Loki version


### PR DESCRIPTION
When running in check mode, the grafana.grafana.loki role fails to execute because a variable is not set. Here is the error message:

```

TASK [grafana.grafana.loki : Latest available Loki version] ********************
Friday 02 August 2024  13:07:53 +0000 (0:00:00.675)       0:00:18.734 ********* 
Friday 02 August 2024  13:07:53 +0000 (0:00:00.675)       0:00:18.733 ********* 
fatal: [172.31.28.208]: FAILED! => {}

MSG:

The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'json'. 'dict object' has no attribute 'json'

The error appears to be in '/opt/github-runner/.ansible/collections/ansible_collections/grafana/grafana/roles/loki/tasks/deploy.yml': line 17, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


    - name: Latest available Loki version
      ^ here

```

I believe the first task in the role, [Scrape Github API endpoint to obtain latest Loki version](https://github.com/grafana/grafana-ansible-collection/blob/main/roles/loki/tasks/deploy.yml#L7), should always be run, even in check mode. 

This PR makes that change.

Fix https://github.com/grafana/grafana-ansible-collection/issues/252#issuecomment-2273296612