### PR TITLE
Fix/promtail loki check mode

### DIFF
--- a/roles/loki/handlers/main.yml
+++ b/roles/loki/handlers/main.yml
@@ -7,3 +7,4 @@
     name: loki.service
     state: restarted
     enabled: true
+  when: not ansible_check_mode

--- a/roles/loki/tasks/deploy.yml
+++ b/roles/loki/tasks/deploy.yml
@@ -135,6 +135,7 @@
   ansible.builtin.systemd:
     name: loki.service
     state: started
+  when: not ansible_check_mode
 
 - name: Verify that Loki URL is responding
   ansible.builtin.uri:
@@ -144,4 +145,6 @@
   retries: 5
   delay: 8
   until: loki_verify_url_status_code.status == 200
-  when: loki_expose_port | bool
+  when:
+    - loki_expose_port | bool
+    - not ansible_check_mode

--- a/roles/promtail/handlers/main.yml
+++ b/roles/promtail/handlers/main.yml
@@ -7,3 +7,4 @@
     name: promtail.service
     state: restarted
     enabled: true
+  when: not ansible_check_mode

--- a/roles/promtail/tasks/deploy.yml
+++ b/roles/promtail/tasks/deploy.yml
@@ -12,6 +12,7 @@
       become: false
       delegate_to: localhost
       run_once: true
+      check_mode: false
       register: __github_latest_version
 
     - name: Latest available Promtail version
@@ -89,6 +90,7 @@
   when:
     - promtail_scrape_configs | length > 0
     - promtail_runtime_mode == "acl"
+    - not ansible_check_mode
 
 - name: Get firewalld state
   ansible.builtin.systemd:
@@ -112,6 +114,7 @@
   ansible.builtin.systemd:
     name: promtail.service
     state: started
+  when: not ansible_check_mode
 
 - name: Stat position file
   ansible.builtin.stat:
@@ -136,4 +139,6 @@
   retries: 5
   delay: 8
   until: promtail_verify_url_status_code.status == 200
-  when: promtail_expose_port | bool
+  when:
+    - promtail_expose_port | bool
+    - not ansible_check_mode


### PR DESCRIPTION
## Why this PR?

The original PR https://github.com/grafana/grafana-ansible-collection/pull/266 appears to be on hold, due to not signing the Contributor License Agreement (CLA). Additionally, it seems to be lacking some necessary changes for Loki and Promtail.

## What Does This PR Change?

I tested Promtail and Loki in check mode and verified that it works on fresh systems where neither Loki nor Promtail is installed. This PR ensures that you can run check mode for both Promtail and Loki.

