### PR TITLE
Allow alloy_user_groups variable again

### DIFF
--- a/roles/alloy/tasks/install.yml
+++ b/roles/alloy/tasks/install.yml
@@ -13,7 +13,7 @@
 - name: Create alloy user
   ansible.builtin.user:
     name: "{{ alloy_service_user }}"
-    group: "{{ alloy_service_group }}"
+    group: "{{ [ alloy_service_group ] + alloy_user_groups }}"
     system: true
     create_home: false  # Appropriate for a system user, usually doesn't need a home directory
   become: true


### PR DESCRIPTION
Hello

Please review this change:
The `{{ [ service_group ] + alloy_user_groups }` was replaced to `{{ alloy_service_group }}` instead of ` {{ [ alloy_service_group ] + alloy_user_groups }}` in [c9000d1106232916440b7d26c7da8f98fb5367b2](https://github.com/grafana/grafana-ansible-collection/commit/c9000d1106232916440b7d26c7da8f98fb5367b2).

Commit [c9000d1106232916440b7d26c7da8f98fb5367b2](https://github.com/grafana/grafana-ansible-collection/commit/c9000d1106232916440b7d26c7da8f98fb5367b2) broke [#212](https://github.com/grafana/grafana-ansible-collection/pull/212)
see comments: 
- [2388057978](https://github.com/grafana/grafana-ansible-collection/pull/212#issuecomment-2388057978) and
- [2388112265](https://github.com/grafana/grafana-ansible-collection/pull/209#issuecomment-2388112265)

Thanks and have a nice day.
