### PR TITLE
fixing groups input

### DIFF
--- a/roles/alloy/tasks/install.yml
+++ b/roles/alloy/tasks/install.yml
@@ -13,7 +13,7 @@
 - name: Create alloy user
   ansible.builtin.user:
     name: "{{ alloy_service_user }}"
-    group: "{{ [ alloy_service_group ] + alloy_user_groups }}"
+    groups: "{{ [ alloy_service_group ] + alloy_user_groups }}"
     system: true
     create_home: false  # Appropriate for a system user, usually doesn't need a home directory
   become: true


### PR DESCRIPTION
Fixing issue with alloy install

```
    "msg": "Group ['alloy', 'adm', 'docker'] does not exist"
```

you can't send in a list to this input.

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#parameter-groups --- `groups` can take a list