### PR TITLE
Fix 'dict object' has no attribute 'path' when running with --check

### DIFF
--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -12,7 +12,9 @@
   become: false
   delegate_to: localhost
   run_once: true
-  when: "grafana_dashboards | length > 0"
+  when:
+    - not ansible_check_mode
+    - "grafana_dashboards | length > 0"
   block:
     - name: "Download grafana dashboard from grafana.net to local directory"
       ansible.builtin.get_url:


### PR DESCRIPTION
When running with --check, the "Download grafana dashboard from grafana.net to local directory" task fails because the destination temporary directory has not been created.

This fix skips this task when ansible_check_mode is set.