### PR TITLE
Allow Alloy to Create Config File directly from File

### DIFF
--- a/roles/alloy/tasks/deploy.yml
+++ b/roles/alloy/tasks/deploy.yml
@@ -91,15 +91,6 @@
   when: alloy_config_file is not defined or alloy_config_file == ""
   notify: restart alloy
 
-- name: Template Alloy config - /etc/alloy/config.alloy
-  ansible.builtin.template:
-    src: "config.alloy.j2"
-    dest: "/etc/alloy/config.alloy"
-    owner: "root"
-    group: "root"
-    mode: "0644"
-  notify: restart alloy
-
 - name: Add the Alloy system user to additional group
   ansible.builtin.user:
     name: "alloy"

--- a/roles/alloy/tasks/deploy.yml
+++ b/roles/alloy/tasks/deploy.yml
@@ -71,6 +71,26 @@
     mode: "0644"
   notify: restart alloy
 
+- name: Copy alloy config file if provided from downstream
+  ansible.builtin.copy:
+    src: "{{ alloy_config_file }}"
+    dest: "/etc/alloy/config.alloy"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  when: alloy_config_file is defined and alloy_config_file != ""
+  notify: restart alloy
+
+- name: Template alloy config file from variable if no file is provided
+  ansible.builtin.template:
+    src: "config.alloy.j2"
+    dest: "/etc/alloy/config.alloy"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  when: alloy_config_file is not defined or alloy_config_file == ""
+  notify: restart alloy
+
 - name: Template Alloy config - /etc/alloy/config.alloy
   ansible.builtin.template:
     src: "config.alloy.j2"


### PR DESCRIPTION
#284 

I want to enhance the configuration setup for Alloy to either accept a direct file from downstream or, if no file is provided, fall back to the existing template mechanism that uses a variable.

## Current Behavior
Currently, the config.alloy.j2 template is used to generate the /etc/alloy/config.alloy file, with the file content entirely dependent on the variable {{ alloy_config }} that holds the content from downstream

## Requested Behavior
Add the ability to provide a file directly from downstream {{ alloy_config_file }}

If alloy_config_file is provided, copy this file directly to /etc/alloy/config.alloy.
If alloy_config_file is not provided, continue using the existing template mechanism with the variable to populate /etc/alloy/config.alloy.
