### PR TITLE
Fix: allow different proxy settings for control node and remote host

### DIFF
--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -5,7 +5,7 @@ alloy_uninstall: false
 alloy_expose_port: false
 alloy_download_url_rpm: "https://github.com/grafana/alloy/releases/download/v{{ alloy_version }}/alloy-{{ alloy_version }}-1.{{ __alloy_arch }}.rpm"
 alloy_download_url_deb: "https://github.com/grafana/alloy/releases/download/v{{ alloy_version }}/alloy-{{ alloy_version }}-1.{{ __alloy_arch }}.deb"
-
+alloy_local_environment: []
 alloy_user_groups: []
 # alloy_user_groups:
 #   - "systemd-journal"

--- a/roles/alloy/tasks/deploy.yml
+++ b/roles/alloy/tasks/deploy.yml
@@ -12,6 +12,7 @@
       run_once: true
       check_mode: false
       register: __github_latest_version
+      environment: "{{ alloy_localhost_environment }}"
 
     - name: Latest available Alloy version
       ansible.builtin.set_fact:


### PR DESCRIPTION
Since the http_proxy, https_proxy urls are different for me on localhost and on the remote target, the alloy role becomes useless. When setting `apply: environment:` in the `include_role` block, either localhost http request are broken or on the remote.

This PR fixes this issue by allowing for an `alloy_locahost_environment` variable to be set, independently of the `apply: environment` mechanism