### PR TITLE
Update grafana template

### DIFF
--- a/roles/grafana/templates/grafana.ini.j2
+++ b/roles/grafana/templates/grafana.ini.j2
@@ -3,18 +3,22 @@
 # http://docs.grafana.org/installation/configuration
 # https://github.com/grafana/grafana/blob/master/conf/sample.ini
 
-{% for k, v in grafana_ini.items() %}
-{% if v is not mapping %}
-{{ k }} = {{ v }}
-{% endif %}
-{% endfor %}
-
 {% for section, items in grafana_ini.items() %}
 {% if items is mapping %}
 [{{ section }}]
-{% for k,v in items.items() %}
+{% for sub_key, sub_value in items.items() %}
+{% if sub_value is mapping %}
+
+[{{ section }}.{{ sub_key }}]
+{% for k, v in sub_value.items() %}
 {{ k }} = {{ v }}
 {% endfor %}
-
+{% else %}
+{{ sub_key }} = {{ sub_value }}
 {% endif %}
+{% endfor %}
+{% else %}
+{{ section }} = {{ items }}
+{% endif %}
+
 {% endfor %}


### PR DESCRIPTION
This PR fixes a bug in the `grafana.ini` creation process.

The issue appeared after https://github.com/grafana/grafana-ansible-collection/pull/232, specifically in https://github.com/grafana/grafana-ansible-collection/pull/232/files#diff-5a971151cd3b0d5b4879eba8415e8b2064b062f86a82779fc6fa24a612c389b7

The current impl. does not handle subsections correctly, such as `auth.ldap`, correctly.

Here is an example of the current output:

```
[auth]
anonymous = {'enabled': False}
basic = {'enabled': True}
ldap = {'allow_sign_up': True, 'config_file': '/etc/grafana/ldap.toml', 'enabled': True}
```

This format is incorrect. It should generate something like: https://github.com/grafana/grafana/blob/main/conf/sample.ini#L637

This PR fixes the issue.