### PR TITLE
Fix sectionless items edge case

### DIFF
--- a/roles/grafana/templates/grafana.ini.j2
+++ b/roles/grafana/templates/grafana.ini.j2
@@ -3,6 +3,12 @@
 # http://docs.grafana.org/installation/configuration
 # https://github.com/grafana/grafana/blob/master/conf/sample.ini
 
+{% for k, v in grafana_ini.items() %}
+{% if v is not mapping %}
+{{ k }} = {{ v }}
+{% endif %}
+{% endfor %}
+
 {% for section, items in grafana_ini.items() %}
 {% if items is mapping %}
 [{{ section }}]
@@ -17,8 +23,6 @@
 {{ sub_key }} = {{ sub_value }}
 {% endif %}
 {% endfor %}
-{% else %}
-{{ section }} = {{ items }}
 {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
This PR fixes an edge case bug introduced by https://github.com/grafana/grafana-ansible-collection/pull/300.

The edge case is explained in https://github.com/grafana/grafana-ansible-collection/pull/300/commits/28a75e1e98b97d0fa7f73d518788e64e8a49c013#r1894068877

The issue occurs because, for sectionless items (keys) to work, they must be at the top. However, the updated grafana template did not guarantee this unless the user explicitly placed them at the top of the `grafana_ini` variable. This approach is suboptimal, as the template should handle this automatically. This PR fixes the issue by managing this edge case first before processing other cases.

Example:

```
    grafana_ini:
      security:
        admin_user: "admin"

      instance_name: "grafana.cloudwerkstatt.dev"
```

With the previous PR, this would generate:

```
[security]
admin_user = admin
admin_email = admin@localhost

instance_name = grafana.cloudwerkstatt.dev
```

This is incorrect, as `instance_name` becomes part of the `security` section and won't be recognized by grafana.

With this PR, the output is correctly generated as:

```
instance_name = grafana.cloudwerkstatt.dev

[security]
admin_user = admin
admin_email = admin@localhost
```
