### PR TITLE
chore: add catalog-info file for internal dev catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana-ansible-collection
+  title: grafana-ansible-collection
+  description: |
+    This collection (grafana.grafana) contains modules and roles to assist in automating the management of resources in Grafana, Grafana Agent, OpenTelemetry Collector, Loki, Mimir, Alloy, and Promtail with Ansible.
+  links:
+    - title: Slack Channel
+      url: https://raintank-corp.slack.com/archives/C04T7GX8C69
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    github.com/project-slug: grafana/grafana-ansible-collection
+spec:
+  type: tool
+  owner: group:default/devex
+  lifecycle: production


### PR DESCRIPTION
Adds catalog information for the internal grafana dev catalog