### PR TITLE
grafana: Add foldersFromFilesStructure option

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -19,6 +19,9 @@ grafana_use_provisioning: true
 # Should the provisioning be kept synced. If true, previous provisioned objects will be removed if not referenced anymore.
 grafana_provisioning_synced: false
 
+# Should we provision dashboards by following the files structure. This sets the foldersFromFilesStructure option
+grafana_provisioning_dashboards_from_file_structure: false
+
 # To enable the use of ports below 1024 for unprivileged processes linux needs to set CAP_NET_BIND_SERVICE.
 # This has some security implications, and should be a conscious choice.
 # Get informed by reading: http://man7.org/linux/man-pages/man7/capabilities.7.html

--- a/roles/grafana/handlers/main.yml
+++ b/roles/grafana/handlers/main.yml
@@ -26,3 +26,23 @@
     mode: "0755"
   become: true
   listen: "provisioned dashboards changed"
+
+- name: "Find dashboards subdirectories"
+  ansible.builtin.find:
+    paths:  "{{ grafana_ini.paths.data }}/dashboards"
+    recurse: yes
+    file_type: directory
+  register: __dashboards_subdirs
+  become: true
+  listen: "provisioned dashboards changed"
+
+- name: "Set privileges on provisioned dashboards sub-directories"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: "directory"
+    recurse: false
+    mode: "0755"
+  with_items:
+    - "{{ __dashboards_subdirs.files | map(attribute='path') | list }}"
+  become: true
+  listen: "provisioned dashboards changed"

--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -98,6 +98,7 @@
               type: file
               options:
                 path: "{{ grafana_ini.paths.data }}/dashboards"
+                foldersFromFilesStructure: {{ grafana_provisioning_dashboards_from_file_structure }}
         backup: false
         owner: root
         group: grafana
@@ -114,7 +115,7 @@
       register: __dashboards_present
       when: grafana_provisioning_synced
 
-    - name: "Import grafana dashboards"
+    - name: "Import grafana.net dashboards"
       ansible.builtin.copy:
         src: "{{ item }}"
         dest: "{{ grafana_ini.paths.data }}/dashboards/{{ item | basename }}"
@@ -123,7 +124,18 @@
         mode: "0640"
       with_fileglob:
         - "{{ __tmp_dashboards.path }}/*"
-        - "{{ grafana_dashboards_dir }}/*.json"
+      become: true
+      register: __dashboards_copied
+      notify: "provisioned dashboards changed"
+      when: not ansible_check_mode
+
+    - name: "Import custom grafana dashboards"
+      ansible.builtin.copy:
+        src: "{{ grafana_dashboards_dir }}"
+        dest: "{{ grafana_ini.paths.data }}/dashboards/"
+        owner: root
+        group: grafana
+        mode: "0640"
       become: true
       register: __dashboards_copied
       notify: "provisioned dashboards changed"

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -110,6 +110,14 @@
         - grafana_run
   when: "grafana_alert_notifications | length > 0 or grafana_alert_resources | length > 0"
 
+- name: Find dashboards to be provisioned
+  ansible.builtin.find:
+    paths: "{{ grafana_dashboards_dir }}"
+    recurse: true
+    patterns: "*.json"
+  delegate_to: localhost
+  register: __found_dashboards
+
 - name: Dashboards
   ansible.builtin.include_tasks:
     file: dashboards.yml
@@ -119,5 +127,3 @@
         - grafana_dashboards
         - grafana_run
   when: "grafana_dashboards | length > 0 or __found_dashboards | length > 0"
-  vars:
-    __found_dashboards: "{{ lookup('fileglob', grafana_dashboards_dir + '/*.json', wantlist=True) }}"


### PR DESCRIPTION
This PR adds support for the provisioning option `foldersFromFilesStructure`.

Changes:
* Add option `grafana_provisioning_dashboards_from_file_structure` which controls `foldersFromFilesStructure`
* Copy whole `grafana_dashboards_dir` directory instead of just the json files to include any potential folder
* Set correct permissions on any dashboard folder
* Switch to `ansible.builtin.find` to check if there are dashboards to import, since [fileglob](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/fileglob_lookup.html) doesn't support recursion.

Closes #277 