### PR TITLE
feat(otelcol): Validate config

### DIFF
--- a/roles/opentelemetry_collector/tasks/configure.yml
+++ b/roles/opentelemetry_collector/tasks/configure.yml
@@ -14,5 +14,6 @@
     owner: "{{ otel_collector_service_user }}"
     group: "{{ otel_collector_service_group }}"
     mode: '0644'
+    validate: '{{ otel_collector_installation_dir }}/{{ otel_collector_executable }} --config={{ otel_collector_config_dir }}/{{ otel_collector_config_file }} validate'
   notify: Restart OpenTelemetry Collector
   become: true


### PR DESCRIPTION
This PR adds a call to `otelcol validate` after templating out the config. This ensures the ansible-playbook run fails when a broken config would be created. This is preferable to the alternative, which is a constantly restarting (and not-working) OpenTelemetry Collector.
