### PR TITLE
Fix loki_operational_config section not getting rendered in config.yml

### DIFF
--- a/roles/loki/templates/config.yml.j2
+++ b/roles/loki/templates/config.yml.j2
@@ -81,7 +81,7 @@ memberlist:
 runtime_config:
   {{ loki_runtime_config | to_nice_yaml(indent=2,sort_keys=False) | indent(2, False) }}
 {% endif %}
-{% if operational_config is defined %}
+{% if loki_operational_config is defined %}
 operational_config:
   {{ loki_operational_config | to_nice_yaml(indent=2,sort_keys=False) | indent(2, False) }}
 {% endif %}


### PR DESCRIPTION
This change fixes the wrong variable name being used in `roles/loki/templates/config.yml.j2`
The `roles/loki/defaults/main.yml` of the Loki role has the `loki_operational_config` commented variable, so I assume it is a typo