### PR TITLE
feat(otel-collector): Make systemd create /var/lib/otel-collector

### DIFF
--- a/roles/opentelemetry_collector/README.md
+++ b/roles/opentelemetry_collector/README.md
@@ -24,6 +24,7 @@ Available variables with their default values are listed below (`defaults/main.y
 | `otel_collector_config_file` | The main configuration file name for the OpenTelemetry Collector. | `"config.yaml"` |
 | `otel_collector_service_user` | The system user under which the OpenTelemetry Collector service will run. | `"otel"` |
 | `otel_collector_service_group` | The system group under which the OpenTelemetry Collector service will run. | `"otel"` |
+| `otel_collector_service_statedirectory` | The directory systemd should create under `/var/lib`. | `"otel-collector"` |
 | `otel_collector_receivers` | Receivers configuration for the OpenTelemetry Collector. | `""` |
 | `otel_collector_exporters` | Exporters configuration for the OpenTelemetry Collector. | `""` |
 | `otel_collector_processors` | Processors configuration for the OpenTelemetry Collector. | `""` |

--- a/roles/opentelemetry_collector/defaults/main.yml
+++ b/roles/opentelemetry_collector/defaults/main.yml
@@ -20,6 +20,7 @@ otel_collector_config_dir: "/etc/otel-collector"
 otel_collector_config_file: "config.yaml"
 otel_collector_service_user: "otel"
 otel_collector_service_group: "otel"
+otel_collector_service_statedirectory: "otel-collector"
 
 otel_collector_receivers: ""
 otel_collector_exporters: ""

--- a/roles/opentelemetry_collector/molecule/default/tests/test_default.py
+++ b/roles/opentelemetry_collector/molecule/default/tests/test_default.py
@@ -11,9 +11,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_directories(host):
-    dirs = [
-        "/etc/otel-collector",
-    ]
+    dirs = ["/etc/otel-collector", "/var/lib/otel-collector"]
     files = ["/etc/otel-collector/config.yaml"]
     for directory in dirs:
         d = host.file(directory)

--- a/roles/opentelemetry_collector/templates/otel_collector.service.j2
+++ b/roles/opentelemetry_collector/templates/otel_collector.service.j2
@@ -8,6 +8,7 @@ ExecStart={{ otel_collector_installation_dir }}/{{ otel_collector_executable }} 
 User={{ otel_collector_service_user }}
 Group={{ otel_collector_service_group }}
 Restart=on-failure
+StateDirectory={{ otel_collector_service_statedirectory }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This makes it easy to write configation with e.g. `file_storage` extensions that need a location to store some state data.
