### PR TITLE
force temporary directory even in check mode for  dashboards.yml

### DIFF
--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -7,6 +7,7 @@
     state: directory
   register: __tmp_dashboards
   changed_when: false
+  check_mode: false
 
 - name: "Download grafana.net dashboards"
   become: false


### PR DESCRIPTION
cf. https://github.com/grafana/grafana-ansible-collection/issues/311 https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_checkmode.html => we need to force the temporary directory creation for the subsequent task not to fail in check mode due to the missing `path`