### PR TITLE
Fix tags Inherit default vars

### DIFF
--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: Inherit default vars
   ansible.builtin.set_fact:
     grafana_ini: "{{ grafana_ini_default | ansible.builtin.combine(grafana_ini, recursive=true) }}"
+  tags:
+    - always
 - name: "Gather variables for each operating system"
   ansible.builtin.include_vars: "{{ distrovars }}"
   vars:


### PR DESCRIPTION
- when run --tags=grafana_configure this task is not running in ansible 2.16.14