### PR TITLE
Update alloy.j2 to correctly embed env file variable options

### DIFF
--- a/roles/alloy/templates/alloy.j2
+++ b/roles/alloy/templates/alloy.j2
@@ -6,5 +6,5 @@ CONFIG_FILE="/etc/alloy/config.alloy"
 RESTART_ON_UPGRADE=true
 
 {% for key, value in alloy_env_file_vars.items() %}
-{{ key}}={{value}}
+{{ key}}="{{value}}"
 {% endfor %}


### PR DESCRIPTION
Env file variable options such as `--stability.level public-preview` in Ansible configurations cause them to be embedded without being escaped in double quotes in the env file.

For context, I have an ansible task that looks like so:
```yaml
    - name: Configure Alloy
      ansible.builtin.include_role:
        name: grafana.grafana.alloy
      vars:
        alloy_config: "{{ lookup('file', '../../Home-Compose/alloy/config.alloy') }}"
        alloy_env_file_vars:
          CUSTOM_ARGS: "--stability.level public-preview"
```

This causes upgrade failures like it did for me today whereby the `prerm` script for the alloy package attempts executing the unescaped half, causing dpkg to spit out the error `/var/lib/dpkg/info/alloy.prerm: 6: /etc/default/alloy: public-preview: not found` for a configuration like so
```
# Ansible Managed

CONFIG_FILE="/etc/alloy/config.alloy"
RESTART_ON_UPGRADE=true

CUSTOM_ARGS=--stability.level public-preview
```

I fixed this by adding escaped quotes to my ansible task such that they get embedded in, like so:
```
CUSTOM_ARGS: "\"--stability.level public-preview\""
```

But this would be best fixed at the source in Jinja.

This occurred to me today by upgrading from alloy `1.6.1-1` to alloy `1.8.1-1`.