### PR TITLE
grafana: Fixes to foldersFromFilesStructure option

### DIFF
--- a/roles/grafana/handlers/main.yml
+++ b/roles/grafana/handlers/main.yml
@@ -14,7 +14,7 @@
     recurse: true
     owner: "grafana"
     group: "grafana"
-    mode: "0640"
+    mode: "u=rwX,g=rX,o=rX"
   become: true
   listen: "provisioned dashboards changed"
 

--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -133,9 +133,19 @@
       ansible.builtin.find:
         paths: "{{ grafana_ini.paths.data }}/dashboards"
         hidden: true
+        recurse: true
         patterns:
           - "*.json"
       register: __dashboards_present
+      when: grafana_provisioning_synced
+
+    - name: "Register previously created folders"
+      ansible.builtin.find:
+        paths: "{{ grafana_ini.paths.data }}/dashboards"
+        recurse: yes
+        file_type: directory
+      register: __dashboards_dir_present
+      become: true
       when: grafana_provisioning_synced
 
     - name: "Import grafana.net dashboards"
@@ -153,15 +163,46 @@
       when: not ansible_check_mode
 
     - name: "Import custom grafana dashboards"
-      ansible.builtin.copy:
-        src: "{{ grafana_dashboards_dir }}"
-        dest: "{{ grafana_ini.paths.data }}/dashboards/"
-        owner: root
-        group: grafana
-        mode: "0640"
-      become: true
-      register: __dashboards_copied
-      notify: "provisioned dashboards changed"
+      block:
+        - name: "Find which directories to create"
+          ansible.builtin.find:
+            paths: "{{ grafana_dashboards_dir }}"
+            recurse: yes
+            file_type: directory
+          register: __dashboards_subdirs
+          delegate_to: localhost
+          become: true
+
+        - name: "Create dashboard folders"
+          ansible.builtin.file:
+            path: "{{ grafana_ini.paths.data }}/dashboards/{{ item }}"
+            state: "directory"
+            recurse: false
+            owner: "grafana"
+            group: "grafana"
+            mode: "0755"
+          loop: "{{ __dashboards_subdirs.files | map(attribute='path') | sort | regex_replace(grafana_dashboards_dir, '') }}"
+          become: true
+          register: __dashboards_dir_created
+          when: not ansible_check_mode
+          
+        - name: "Copy dashboard files"
+          ansible.builtin.copy:
+            src: "{{ item.path }}"
+            dest: '{{ grafana_ini.paths.data }}/dashboards/{{ item.path | regex_replace(grafana_dashboards_dir, "") }}'
+            owner: root
+            group: grafana
+            mode: "0644"
+          loop: "{{ __found_dashboards | json_query('files[*]') }}"
+          become: true
+          register: __dashboards_copied
+          notify: "provisioned dashboards changed"
+          when: not ansible_check_mode
+
+    - name: "Register present and copied folders list"
+      ansible.builtin.set_fact:
+        __folders_present_list: "{{ __dashboards_dir_present | json_query('files[*].path') | default([]) }}"
+        __folders_copied_list: "{{ __dashboards_dir_created | json_query('results[*].path') | default([]) }}"
       when: not ansible_check_mode
 
     - name: "Register present and copied dashboards list"
@@ -175,5 +216,13 @@
         path: "{{ item }}"
         state: absent
       loop: "{{ __dashboards_present_list | difference(__dashboards_copied_list) }}"
+      become: true
+      when: grafana_provisioning_synced and not ansible_check_mode
+
+    - name: "Remove folders not present on deployer machine (synchronize)"
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ __folders_present_list | difference(__folders_copied_list) }}"
       become: true
       when: grafana_provisioning_synced and not ansible_check_mode


### PR DESCRIPTION
This PR includes some additional fixes for the `foldersFromFilesStructure` introduced in https://github.com/grafana/grafana-ansible-collection/pull/326 which was incomplete.

1. It correctly handles creating folders from the file structures under `{{ grafana_dashboards_dir }}` while
2. Registers the created and present dashboards folders and adds a task to remove the folders that should not be present if `grafana_provisioning_synced` is enabled
3. Fixes folders permissions to be 0755 and files permissions to be 0644 by using `u=rwX,g=rX,o=rX`

Given a `{{ grafana_dashboards_dir }}` directory structure of:

```
├── dash1.json
├── dash2.json
└── folder
    └── dash3.json
```

the role will create this exact structure under `/var/lib/grafana/dashboards`.