### PR TITLE
fix(otel-collector): properly validate config

### DIFF
--- a/roles/opentelemetry_collector/tasks/configure.yml
+++ b/roles/opentelemetry_collector/tasks/configure.yml
@@ -14,6 +14,6 @@
     owner: "{{ otel_collector_service_user }}"
     group: "{{ otel_collector_service_group }}"
     mode: '0644'
-    validate: '{{ otel_collector_installation_dir }}/{{ otel_collector_executable }} --config={{ otel_collector_config_dir }}/{{ otel_collector_config_file }} validate'
+    validate: '{{ otel_collector_installation_dir }}/{{ otel_collector_executable }} --config=%s validate'
   notify: Restart OpenTelemetry Collector
   become: true


### PR DESCRIPTION
Somehow, when actually deploying this in a production environment (using Ansible 10.7.0 and ansible-core 2.17.11) I got this error:

> `FAILED! => {"changed": false, "checksum": "9db8f25bf3e8d3989788959c64ee0f922ef9275f", "msg": "validate must contain %s: /etc/otel-collector/otelcol-contrib --config=/etc/otel-collector/config.yaml validate"}`

This PR fixes that issue, which was a bug in the first place.

I don't know why the tests did not pick this up.
