### PR TITLE
Fix Mimir URL verify task

### DIFF
--- a/roles/mimir/tasks/deploy.yml
+++ b/roles/mimir/tasks/deploy.yml
@@ -101,7 +101,7 @@
 
 - name: Verify that Mimir URL is responding
   ansible.builtin.uri:
-    url: "http://127.0.0.1:{{ mimir_http_listen_port }}/ready"
+    url: "http://{{ mimir_http_listen_address }}:{{ mimir_http_listen_port }}/ready"
     method: GET
   register: mimir_verify_url_status_code
   retries: 5


### PR DESCRIPTION
Hi :wave: 

This PR changes the Ansible that verifies Mimir URL to ensure it is using the chosen HTTP listen address.

I've found out that it fails when I set `mimir_http_listen_address` to an IP that doesn't includes localhost (like `0.0.0.0`).

Tested it locally with Molecule by making this change to the vars:

```diff
diff --git a/roles/mimir/molecule/default/converge.yml b/roles/mimir/molecule/default/converge.yml
index 57a36c0..3b82453 100644
--- a/roles/mimir/molecule/default/converge.yml
+++ b/roles/mimir/molecule/default/converge.yml
@@ -4,6 +4,7 @@
   collections:
     - grafana.grafana
   vars:
+    mimir_http_listen_address: "{{ ansible_facts['default_ipv4']['address'] }}"
     mimir_storage:
       storage:
         backend: s3
```

If you test this without my change, the converge will fail.