### PR TITLE
Update when statement to test for dashboard files found

### DIFF
--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -129,4 +129,4 @@
         - grafana_configure
         - grafana_dashboards
         - grafana_run
-  when: "grafana_dashboards | length > 0 or __found_dashboards | length > 0"
+  when: "grafana_dashboards | length > 0 or __found_dashboards['files'] | length > 0"


### PR DESCRIPTION
The result of "__found_dashboards" is always larger than 0 because it's just the result of the task. We need to test for any files found by using ['files'] because that is a list of results.