### PR TITLE
grafana role: ensure alerting provisioning directory exists

### DIFF
--- a/roles/grafana/tasks/configure.yml
+++ b/roles/grafana/tasks/configure.yml
@@ -15,6 +15,7 @@
     - path: "/etc/grafana/provisioning/notifiers"
     - path: "/etc/grafana/provisioning/notification"
     - path: "/etc/grafana/provisioning/plugins"
+    - path: "/etc/grafana/provisioning/alerting"
     - path: "{{ grafana_ini.paths.logs }}"
       owner: grafana
     - path: "{{ grafana_ini.paths.data }}"


### PR DESCRIPTION
Without this directory, deploying Grafana using `grafana.grafana` with `grafana_alert_resources` would fail because `/etc/grafana/provisioning/alerting` is missing.