### PR TITLE
Use become false in find task

### DIFF
--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -119,6 +119,7 @@
     recurse: true
     patterns: "*.json"
   delegate_to: localhost
+  become: false
   register: __found_dashboards
 
 - name: Dashboards


### PR DESCRIPTION
This PR fixes #357.

As @rthomson mentioned, there is no need to use privileged mode for this task, so setting `become: false` should be a simple fix for the error:

```
TASK [grafana.grafana.grafana : Find dashboards to be provisioned] *****************************************************************************************
fatal: [<REDCATED> -> localhost]: FAILED! => changed=false
  module_stderr: |-
    sudo: a password is required
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

This code was added a month ago in https://github.com/grafana/grafana-ansible-collection/pull/326. 