### PR TITLE
[examples] improve mimir/alloy examples playbook

### DIFF
--- a/examples/alloy.yaml
+++ b/examples/alloy.yaml
@@ -4,18 +4,14 @@
   become: true
   roles:
     - role: grafana.grafana.alloy
-  tasks:
-    - name: Deploy alloy
-      ansible.builtin.include_role:
-        name: grafana.grafana.alloy
-      vars:
-        alloy_config: |
-          prometheus.scrape "default" {
-              targets = [{"__address__" = "127.0.0.1:12345"}]
-              forward_to = [prometheus.remote_write.prom.receiver]
-          }
-          prometheus.remote_write "prom" {
-            endpoint {
-                url = "http://mimir:9009/api/v1/push"
-            }
-          }
+  vars:
+    alloy_config: |
+      prometheus.scrape "default" {
+          targets = [{"__address__" = "127.0.0.1:12345"}]
+          forward_to = [prometheus.remote_write.prom.receiver]
+      }
+      prometheus.remote_write "prom" {
+        endpoint {
+            url = "http://mimir:9009/api/v1/push"
+        }
+      }

--- a/examples/mimir-3-hosts.yaml
+++ b/examples/mimir-3-hosts.yaml
@@ -7,26 +7,26 @@
       ansible.builtin.include_role:
         name: grafana.grafana.mimir
       vars:
-      # Run against minio blob store backed, see readme for local setup or mimir docs for Azure, AWS, etc.
-      mimir_storage:
-        storage:
-          backend: s3
-          s3:
-            endpoint: localhost:9000
-            access_key_id: testtest
-            secret_access_key: testtest
-            insecure: true
-            bucket_name: mimir
+        # Run against minio blob store backed, see readme for local setup or mimir docs for Azure,   AWS, etc.
+        mimir_storage:
+          storage:
+            backend: s3
+            s3:
+              endpoint: localhost:9000
+              access_key_id: testtest
+              secret_access_key: testtest
+              insecure: true
+              bucket_name: mimir
 
-      # Blocks storage requires a prefix when using a common object storage bucket.
-      mimir_blocks_storage:
-        storage_prefix: blocks
-        tsdb:
-          dir: "{{ mimir_working_path}}/ingester"
+        # Blocks storage requires a prefix when using a common object storage bucket.
+        mimir_blocks_storage:
+          storage_prefix: blocks
+          tsdb:
+            dir: "{{ mimir_working_path}}/ingester"
 
-      # Use memberlist, a gossip-based protocol, to enable the 3 Mimir replicas to communicate
-      mimir_memberlist:
-        join_members:
-          - mimir-1:7946
-          - mimir-2:7946
-          - mimir-3:7946
+        # Use memberlist, a gossip-based protocol, to enable the 3 Mimir replicas to communicate
+        mimir_memberlist:
+          join_members:
+            - mimir-1:7946
+            - mimir-2:7946
+            - mimir-3:7946


### PR DESCRIPTION
When testing the default example playbook I had issue with variables "undefined" when running Ansible. 
It seems some part weren't properly indented and I had to add small fixes. 

This is the changes if you want I can review and check a bit more the doc if there is anything else not working.