### PR TITLE
Mimir: Don't override defaults

### DIFF
--- a/roles/mimir/defaults/main.yml
+++ b/roles/mimir/defaults/main.yml
@@ -7,9 +7,6 @@ mimir_download_url_rpm: "https://github.com/grafana/mimir/releases/download/{{ m
 mimir_download_url_deb: "https://github.com/grafana/mimir/releases/download/{{ mimir_version }}/{{ mimir_version }}_{{ __mimir_arch }}.deb"
 mimir_working_path: "/var/lib/mimir"
 mimir_ruler_alert_path: "{{ mimir_working_path }}/ruler"
-mimir_http_listen_port: 8080
-mimir_http_listen_address: "0.0.0.0"
-mimir_log_level: warn
 
 arch_mapping:
   x86_64: amd64
@@ -21,18 +18,8 @@ arch_mapping:
 mimir_ruler:
   rule_path: "{{ mimir_working_path }}/ruler"
   alertmanager_url: "http://127.0.0.1:{{ mimir_http_listen_port }}/alertmanager"
-  ring:
-    heartbeat_period: 5s
-    heartbeat_timeout: 10s
 
 mimir_alertmanager:
   data_dir: "{{ mimir_working_path }}/alertmanager"
   external_url: "http://localhost:{{ mimir_http_listen_port }}/alertmanager"
 
-mimir_server:
-  http_listen_port: "{{ mimir_http_listen_port }}"
-  http_listen_address: "{{ mimir_http_listen_address }}"
-  log_level: "{{ mimir_log_level }}"
-
-mimir_limits:
-  compactor_blocks_retention_period: 6m


### PR DESCRIPTION
The default values for these settings shouldn't be overridden by default unless explicitly configured by users. The defaults in Mimir itself are picked to be useable in production already.

Related https://github.com/grafana/mimir/issues/11599