### PR TITLE
fix: ensure IP assert returns boolean result

### DIFF
--- a/roles/alloy/tasks/preflight.yml
+++ b/roles/alloy/tasks/preflight.yml
@@ -22,5 +22,5 @@
 
     - name: Assert that extracted IP address is valid
       ansible.builtin.assert:
-        that: __alloy_server_http_listen_address | ansible.utils.ipaddr
+        that: (__alloy_server_http_listen_address | ansible.utils.ipaddr) != ""
       when: __alloy_server_http_listen_addr_regex | length > 0


### PR DESCRIPTION
Ansible 2.19 introduced a breaking change that made the assert condition fail consistently:

https://github.com/ansible/ansible/blob/v2.19.0/changelogs/CHANGELOG-v2.19.rst

> conditionals - Conditional expressions that result in non-boolean values are now an error by default. Such results often indicate unintentional use of templates where they are not supported, resulting in a conditional that is always true. When this option is enabled, conditional expressions which are a literal None or empty string will evaluate as true, for backwards compatibility. The error can be temporarily changed to a deprecation warning by enabling the ALLOW_BROKEN_CONDITIONALS config option.


This change makes sure the result is always a boolean