### PR TITLE
fix(grafana): Fallback to empty dict in case grafana_ini is undefined

### DIFF
--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Inherit default vars
   ansible.builtin.set_fact:
-    grafana_ini: "{{ grafana_ini_default | ansible.builtin.combine(grafana_ini, recursive=true) }}"
+    grafana_ini: "{{ grafana_ini_default | ansible.builtin.combine(grafana_ini | default({}), recursive=true) }}"
   no_log: "{{ 'false' if lookup('env', 'CI') else 'true' }}"
   tags:
     - always


### PR DESCRIPTION
The playbook will fail further down on the preflight check since `grafana_ini.security.admin_password` is not set. But, this outputs a nice meessage to the user instead of the `no_log` message on the inherit default vars task.

```
TASK [grafana.grafana.grafana : Inherit default vars] **************************
ok: [default] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

TASK [grafana.grafana.grafana : Gather variables for each operating system] ****
ok: [default] => {"ansible_facts": {"_grafana_dependencies": ["chkconfig"], "grafana_package": "grafana{{ (grafana_version != 'latest') | ternary('-' ~ grafana_version, '') }}"}, "ansible_included_var_files": ["/home/vagrant/.ansible/collections/ansible_collections/grafana/grafana/roles/grafana/vars/distro/redhat.yml"], "changed": false}

TASK [grafana.grafana.grafana : Preflight] *************************************
included: /home/vagrant/.ansible/collections/ansible_collections/grafana/grafana/roles/grafana/tasks/preflight.yml for default

TASK [grafana.grafana.grafana : Check variable types] **************************
ok: [default] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [grafana.grafana.grafana : Fail when datasources aren't configured when dashboards are set to be installed] ***
skipping: [default] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [grafana.grafana.grafana : Fail when grafana admin user isn't set] ********
skipping: [default] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [grafana.grafana.grafana : Fail when grafana admin password isn't set] ****
fatal: [default]: FAILED! => {"changed": false, "msg": "Please specify grafana admin password (grafana_ini.security.admin_password)"}
```

Fixes #320 