### PR TITLE
Grafana - Update "Install dependencies" task condition

### DIFF
--- a/roles/grafana/tasks/install.yml
+++ b/roles/grafana/tasks/install.yml
@@ -9,7 +9,7 @@
     name: "{{ _grafana_dependencies }}"
     state: present
     update_cache: true
-  when: "(_grafana_dependencies | default())"
+  when: "_grafana_dependencies is defined and _grafana_dependencies | length > 0"
 
 - name: "Prepare zypper"
   when:
@@ -28,7 +28,7 @@
         description: grafana
         repo: "{{ grafana_yum_repo }}"
         enabled: true
-        disable_gpg_check : "{{ false if (grafana_yum_key) else omit }}"
+        disable_gpg_check: "{{ false if (grafana_yum_key) else omit }}"
         runrefresh: true
       when: "(not grafana_rhsm_repo)"
 


### PR DESCRIPTION
Starting from ansible 2.19 there's no automatic boolean casting anymore: https://ansible.readthedocs.io/projects/ansible-core/devel/porting_guides/porting_guide_core_2.19.html, so only conditions which return `true` or `falce` explicitly should be used with `when`.