### PR TITLE
feat: add macOS support to alloy role

### DIFF
--- a/roles/alloy/README.md
+++ b/roles/alloy/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/grafana/grafana-ansible-collection)](LICENSE)
 
 This Ansible role to install and configure [Alloy](https://grafana.com/docs/alloy/latest/), which can be used to collect traces, metrics, and logs.
-This role is tailored for operating systems such as **RedHat**, **Rocky Linux**, **AlmaLinux**, **Ubuntu**, and **Debian**.
+This role is tailored for operating systems such as **RedHat**, **Rocky Linux**, **AlmaLinux**, **Ubuntu**, **Debian**, and **macOS**.
 
 ## Table of Content
 
@@ -15,6 +15,8 @@ This role is tailored for operating systems such as **RedHat**, **Rocky Linux**,
 
 - Ansible 2.13+
 - `ansible.utils` collection is required. Additionally, you must install the `netaddr` Python library on the host where you are running Ansible (not on the target remote host) if is not present.
+- `community.general` collection is required for macOS support
+- **macOS**: Homebrew must be installed
 
 ## Role Variables
 

--- a/roles/alloy/handlers/main.yml
+++ b/roles/alloy/handlers/main.yml
@@ -8,3 +8,10 @@
     state: restarted
     enabled: true
   when: not ansible_check_mode
+
+- name: Restart alloy macos
+  listen: "restart alloy macos"
+  ansible.builtin.command: "brew services restart {{ __alloy_brew_package }}"
+  when:
+    - not ansible_check_mode
+    - ansible_facts['os_family'] == 'Darwin'

--- a/roles/alloy/meta/main.yml
+++ b/roles/alloy/meta/main.yml
@@ -19,7 +19,11 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - all
+    - name: macOS
+      versions:
+        - all
   galaxy_tags:
+    - alloy
     - grafana
     - observability
     - monitoring

--- a/roles/alloy/tasks/deploy.yml
+++ b/roles/alloy/tasks/deploy.yml
@@ -18,6 +18,7 @@
         alloy_version: "{{ __github_latest_version.json.tag_name | regex_replace('^v?(\\d+\\.\\d+\\.\\d+)$', '\\1') }}"
 
 - name: Verify current deployed version
+  when: ansible_facts['os_family'] in ['RedHat', 'Debian']
   block:
     - name: Check if Alloy binary is present
       ansible.builtin.stat:
@@ -31,6 +32,21 @@
       register: __current_deployed_version
       when: __already_deployed.stat.exists | bool
 
+- name: Verify current deployed version on macOS
+  when: ansible_facts['os_family'] == 'Darwin'
+  block:
+    - name: Check if Alloy is installed via Homebrew
+      ansible.builtin.command: brew list --versions {{ __alloy_brew_package }}
+      register: __brew_alloy_version
+      failed_when: false
+      changed_when: false
+
+    - name: Extract current Alloy version on macOS
+      ansible.builtin.set_fact:
+        __current_deployed_version:
+          stdout: "{{ __brew_alloy_version.stdout }}"
+      when: __brew_alloy_version.rc == 0
+
 - name: Include RedHat/Rocky setup
   ansible.builtin.include_tasks:
     file: setup-RedHat.yml
@@ -41,8 +57,15 @@
     file: setup-Debian.yml
   when: ansible_facts['os_family'] == 'Debian'
 
+- name: Include macOS/Darwin setup
+  ansible.builtin.include_tasks:
+    file: setup-Darwin.yml
+  when: ansible_facts['os_family'] == 'Darwin'
+
 - name: Alloy systemd override
-  when: alloy_systemd_override | length > 0
+  when:
+    - alloy_systemd_override | length > 0
+    - ansible_facts['os_family'] in ['RedHat', 'Debian']
   block:
     - name: Ensure that Alloy systemd override path exist
       ansible.builtin.file:
@@ -70,6 +93,7 @@
     group: "root"
     mode: "0644"
   notify: restart alloy
+  when: ansible_facts['os_family'] in ['RedHat', 'Debian']
 
 - name: Template Alloy config - /etc/alloy/config.alloy
   ansible.builtin.template:
@@ -81,6 +105,7 @@
   when:
     - alloy_config | length > 0
     - alloy_env_file_vars.CONFIG_FILE is not defined
+    - ansible_facts['os_family'] in ['RedHat', 'Debian']
   notify: restart alloy
 
 - name: Ensure that /etc/alloy/alloy.config is absent when a custom configuration file/dir is specified in alloy_env_file_vars.CONFIG_FILE
@@ -89,6 +114,7 @@
     state: absent
   when:
     - alloy_config | length < 1 or alloy_env_file_vars.CONFIG_FILE is defined
+    - ansible_facts['os_family'] in ['RedHat', 'Debian']
 
 - name: Add the Alloy system user to additional group
   ansible.builtin.user:
@@ -101,11 +127,13 @@
   loop: "{{ alloy_user_groups }}"
   when:
     - alloy_user_groups | length > 0
+    - ansible_facts['os_family'] in ['RedHat', 'Debian']
 
 - name: Get firewalld state
   ansible.builtin.systemd:
     name: "firewalld"
   register: __firewalld_service_state
+  when: ansible_facts['os_family'] in ['RedHat', 'Debian']
 
 - name: Enable firewalld rule to expose Alloy tcp port {{ __alloy_server_http_listen_port }}
   ansible.posix.firewalld:
@@ -114,17 +142,20 @@
     port: "{{ __alloy_server_http_listen_port }}/tcp"
     state: enabled
   when:
+    - ansible_facts['os_family'] in ['RedHat', 'Debian']
     - __firewalld_service_state.status.ActiveState == "active"
     - alloy_expose_port | bool
 
 - name: Flush handlers after deployment
   ansible.builtin.meta: flush_handlers
 
-- name: Ensure that Alloy is started
+- name: Ensure that Alloy is started (Linux)
   ansible.builtin.systemd:
     name: alloy.service
     state: started
-  when: not ansible_check_mode
+  when:
+    - not ansible_check_mode
+    - ansible_facts['os_family'] in ['RedHat', 'Debian']
 
 - name: Verify that Alloy URL is responding
   ansible.builtin.uri:
@@ -137,3 +168,4 @@
   until: __alloy_verify_url_status_code.status == 200
   when:
     - not ansible_check_mode
+    - ansible_facts['os_family'] in ['RedHat', 'Debian']

--- a/roles/alloy/tasks/setup-Darwin.yml
+++ b/roles/alloy/tasks/setup-Darwin.yml
@@ -1,0 +1,106 @@
+---
+- name: Check if Homebrew is installed
+  ansible.builtin.command: which brew
+  register: brew_check
+  changed_when: false
+  failed_when: false
+
+- name: Fail if Homebrew is not installed
+  ansible.builtin.fail:
+    msg: "Homebrew is required but not installed"
+  when: brew_check.rc != 0
+
+- name: Get Homebrew prefix
+  ansible.builtin.command: brew --prefix
+  register: brew_prefix
+  changed_when: false
+
+- name: Set Alloy config directory path
+  ansible.builtin.set_fact:
+    alloy_config_path: "{{ __alloy_config_path_default }}"
+
+- name: Add Grafana tap to Homebrew
+  community.general.homebrew_tap:
+    name: "{{ __alloy_brew_tap }}"
+    state: present
+
+- name: Install Alloy via Homebrew
+  community.general.homebrew:
+    name: "{{ __alloy_brew_package }}"
+    state: present
+    update_homebrew: true
+
+- name: Ensure Alloy config directory exists
+  ansible.builtin.file:
+    path: "{{ alloy_config_path }}"
+    state: directory
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_gid }}"
+    mode: '0755'
+
+- name: Template Alloy config
+  ansible.builtin.template:
+    src: "config.alloy.j2"
+    dest: "{{ alloy_config_path }}/config.alloy"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_gid }}"
+    mode: '0644'
+    backup: true
+  when: alloy_config | length > 0
+  notify: restart alloy macos
+
+- name: Check if Alloy service is loaded
+  ansible.builtin.command: brew services list
+  register: brew_services
+  changed_when: false
+
+- name: Stop Alloy service if it exists (to clean up any issues)
+  ansible.builtin.command: "brew services stop {{ __alloy_brew_package }}"
+  register: stop_result
+  failed_when: false
+  changed_when: "'Successfully stopped' in stop_result.stdout"
+  when: "'alloy' in brew_services.stdout"
+
+- name: Start Alloy service with sudo (for first-time setup)
+  ansible.builtin.command: "sudo brew services start {{ __alloy_brew_package }}"
+  become: true
+  when:
+    - "'alloy' not in brew_services.stdout or 'none' in brew_services.stdout"
+  register: service_start_sudo
+  failed_when: false
+
+- name: Start Alloy service without sudo (for user-level service)
+  ansible.builtin.command: "brew services start {{ __alloy_brew_package }}"
+  when:
+    - service_start_sudo is not defined or service_start_sudo.rc != 0
+    - "'alloy' not in brew_services.stdout or 'started' not in brew_services.stdout"
+  register: service_start
+  failed_when: false
+
+- name: Restart Alloy service if already running
+  ansible.builtin.command: "brew services restart {{ __alloy_brew_package }}"
+  when:
+    - "'alloy' in brew_services.stdout and 'started' in brew_services.stdout"
+    - service_start is not defined or not service_start.changed
+  register: service_restart
+  failed_when: false
+
+- name: Check final service status
+  ansible.builtin.command: brew services list
+  register: final_brew_services
+  changed_when: false
+
+- name: Verify Alloy installation
+  ansible.builtin.command: alloy --version
+  register: alloy_version_output
+  changed_when: false
+  failed_when: false
+
+- name: Display Alloy version
+  ansible.builtin.debug:
+    msg: "Alloy version: {{ alloy_version_output.stdout }}"
+  when: alloy_version_output.rc == 0
+
+- name: Display service status
+  ansible.builtin.debug:
+    msg: "Alloy service status: {{ final_brew_services.stdout_lines | select('match', '.*alloy.*') | list }}"

--- a/roles/alloy/tasks/uninstall.yml
+++ b/roles/alloy/tasks/uninstall.yml
@@ -5,6 +5,11 @@
     state: stopped
   ignore_errors: true
 
+- name: Stop Alloy service on macOS
+  ansible.builtin.command: "brew services stop {{ __alloy_brew_package }}"
+  when: ansible_facts['os_family'] == 'Darwin'
+  failed_when: false
+
 - name: Uninstall Alloy rpm package
   ansible.builtin.dnf:
     name: "alloy"
@@ -18,6 +23,12 @@
     state: absent
     purge: true
   when: ansible_facts['os_family'] == 'Debian'
+
+- name: Uninstall Alloy via Homebrew
+  community.general.homebrew:
+    name: "{{ __alloy_brew_package }}"
+    state: absent
+  when: ansible_facts['os_family'] == 'Darwin'
 
 - name: Ensure that Alloy firewalld rule is not present - tcp port {{ __alloy_server_http_listen_port }}
   ansible.posix.firewalld:  # noqa ignore-errors
@@ -39,6 +50,12 @@
     - "/etc/default/alloy"
   loop_control:
     loop_var: remove_me
+
+- name: Remove Alloy config directory on macOS
+  ansible.builtin.file:
+    path: "{{ __alloy_config_path_default }}"
+    state: absent
+  when: ansible_facts['os_family'] == 'Darwin'
 
 - name: Remove the Alloy system user
   ansible.builtin.user:

--- a/roles/alloy/vars/Darwin.yml
+++ b/roles/alloy/vars/Darwin.yml
@@ -1,0 +1,5 @@
+---
+# macOS/Darwin specific variables
+__alloy_brew_tap: "grafana/grafana"
+__alloy_brew_package: "grafana/grafana/alloy"
+__alloy_config_path_default: "{{ brew_prefix.stdout | default('/opt/homebrew') }}/etc/alloy"


### PR DESCRIPTION
**Added:**

- Introduced macOS (Darwin) support for installing and managing Alloy, including a dedicated `setup-Darwin.yml` task file leveraging Homebrew for package management and service control (as per https://grafana.com/docs/alloy/latest/set-up/install/macos/)
- Added macOS-specific handler to restart Alloy using Homebrew services
- Defined Darwin-specific variables in `vars/Darwin.yml` for Homebrew tap, package, and default config path
- Updated role metadata to declare macOS platform support

**Changed:**

- Updated documentation to mention macOS as a supported OS and specify Homebrew and `community.general` requirements
- Modified deployment tasks to conditionally execute Linux-specific logic only on RedHat and Debian families, and add macOS-specific verification and setup
- Adjusted handler logic to include macOS restart handler
- Improved uninstall logic to stop Alloy and remove config on macOS, and uninstall via Homebrew when appropriate