### PR TITLE
Fixes issue #420

### DIFF
--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -194,5 +194,7 @@
       loop: "{{ __dashboards_present_list | difference(__dashboards_copied_list) }}"
       become: true
       when: 
+        - __dashboards_present_list is defined and __dashboards_present_list
+        - __dashboards_copied_list is defined and __dashboards_copied_list
         - grafana_provisioning_synced | bool
         - not ansible_check_mode

--- a/roles/grafana/tasks/install.yml
+++ b/roles/grafana/tasks/install.yml
@@ -9,7 +9,9 @@
     name: "{{ _grafana_dependencies }}"
     state: present
     update_cache: true
-  when: "(_grafana_dependencies | default())"
+  when:
+   - _grafana_dependencies is defined
+   - _grafana_dependencies | length > 0
 
 - name: "Prepare zypper"
   when:


### PR DESCRIPTION
The grafana role breaks on Ansible >= 2.19 due to a breaking change in how conditionals are managed.

More info: https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_core_2.19.html#broken-conditionals

```
10     state: present
11     update_cache: true
12   when: "(_grafana_dependencies | default())"
           ^ column 9

Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.
```