### PR TITLE
Add SUSE support to Alloy role

### DIFF
--- a/.github/workflows/alloy-molecule.yml
+++ b/.github/workflows/alloy-molecule.yml
@@ -23,6 +23,7 @@ jobs:
           - rockylinux9
           - ubuntu2204
           - debian12
+          - opensuseleap15
 
     steps:
       - name: Check out the codebase.

--- a/roles/alloy/README.md
+++ b/roles/alloy/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/grafana/grafana-ansible-collection)](LICENSE)
 
 This Ansible role to install and configure [Alloy](https://grafana.com/docs/alloy/latest/), which can be used to collect traces, metrics, and logs.
-This role is tailored for operating systems such as **RedHat**, **Rocky Linux**, **AlmaLinux**, **Ubuntu**, **Debian**, and **macOS**.
+This role is tailored for operating systems such as **RedHat**, **Rocky Linux**, **AlmaLinux**, **Ubuntu**, **Debian**, **macOS**, and **openSUSE**.
 
 ## Table of Content
 

--- a/roles/alloy/meta/main.yml
+++ b/roles/alloy/meta/main.yml
@@ -22,6 +22,9 @@ galaxy_info:
     - name: macOS
       versions:
         - all
+    - name: opensuse
+      versions:
+        - all
   galaxy_tags:
     - alloy
     - grafana

--- a/roles/alloy/tasks/deploy.yml
+++ b/roles/alloy/tasks/deploy.yml
@@ -18,7 +18,7 @@
         alloy_version: "{{ __github_latest_version.json.tag_name | regex_replace('^v?(\\d+\\.\\d+\\.\\d+)$', '\\1') }}"
 
 - name: Verify current deployed version
-  when: ansible_facts['os_family'] in ['RedHat', 'Debian']
+  when: ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
   block:
     - name: Check if Alloy binary is present
       ansible.builtin.stat:
@@ -62,10 +62,15 @@
     file: setup-Darwin.yml
   when: ansible_facts['os_family'] == 'Darwin'
 
+- name: Include SUSE setup
+  ansible.builtin.include_tasks:
+    file: setup-Suse.yml
+  when: ansible_facts['os_family'] == 'Suse'
+
 - name: Alloy systemd override
   when:
     - alloy_systemd_override | length > 0
-    - ansible_facts['os_family'] in ['RedHat', 'Debian']
+    - ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
   block:
     - name: Ensure that Alloy systemd override path exist
       ansible.builtin.file:
@@ -93,7 +98,7 @@
     group: "root"
     mode: "0644"
   notify: restart alloy
-  when: ansible_facts['os_family'] in ['RedHat', 'Debian']
+  when: ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
 
 - name: Template Alloy config - /etc/alloy/config.alloy
   ansible.builtin.template:
@@ -105,7 +110,7 @@
   when:
     - alloy_config | length > 0
     - alloy_env_file_vars.CONFIG_FILE is not defined
-    - ansible_facts['os_family'] in ['RedHat', 'Debian']
+    - ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
   notify: restart alloy
 
 - name: Ensure that /etc/alloy/alloy.config is absent when a custom configuration file/dir is specified in alloy_env_file_vars.CONFIG_FILE
@@ -114,7 +119,7 @@
     state: absent
   when:
     - alloy_config | length < 1 or alloy_env_file_vars.CONFIG_FILE is defined
-    - ansible_facts['os_family'] in ['RedHat', 'Debian']
+    - ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
 
 - name: Add the Alloy system user to additional group
   ansible.builtin.user:
@@ -127,13 +132,13 @@
   loop: "{{ alloy_user_groups }}"
   when:
     - alloy_user_groups | length > 0
-    - ansible_facts['os_family'] in ['RedHat', 'Debian']
+    - ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
 
 - name: Get firewalld state
   ansible.builtin.systemd:
     name: "firewalld"
   register: __firewalld_service_state
-  when: ansible_facts['os_family'] in ['RedHat', 'Debian']
+  when: ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
 
 - name: Enable firewalld rule to expose Alloy tcp port {{ __alloy_server_http_listen_port }}
   ansible.posix.firewalld:
@@ -142,7 +147,7 @@
     port: "{{ __alloy_server_http_listen_port }}/tcp"
     state: enabled
   when:
-    - ansible_facts['os_family'] in ['RedHat', 'Debian']
+    - ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
     - __firewalld_service_state.status.ActiveState == "active"
     - alloy_expose_port | bool
 
@@ -155,7 +160,7 @@
     state: started
   when:
     - not ansible_check_mode
-    - ansible_facts['os_family'] in ['RedHat', 'Debian']
+    - ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
 
 - name: Verify that Alloy URL is responding
   ansible.builtin.uri:
@@ -168,4 +173,4 @@
   until: __alloy_verify_url_status_code.status == 200
   when:
     - not ansible_check_mode
-    - ansible_facts['os_family'] in ['RedHat', 'Debian']
+    - ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']

--- a/roles/alloy/tasks/setup-Suse.yml
+++ b/roles/alloy/tasks/setup-Suse.yml
@@ -1,0 +1,8 @@
+---
+- name: Zypper - Install Alloy from remote URL
+  community.general.zypper:
+    name: "{{ alloy_download_url_rpm }}"
+    state: present
+    disable_gpg_check: true
+  notify: restart alloy
+  when: __current_deployed_version.stdout is not defined or alloy_version not in __current_deployed_version.stdout

--- a/roles/alloy/tasks/uninstall.yml
+++ b/roles/alloy/tasks/uninstall.yml
@@ -30,6 +30,12 @@
     state: absent
   when: ansible_facts['os_family'] == 'Darwin'
 
+- name: Uninstall Alloy rpm package (SUSE)
+  community.general.zypper:
+    name: "alloy"
+    state: absent
+  when: ansible_facts['os_family'] == 'Suse'
+
 - name: Ensure that Alloy firewalld rule is not present - tcp port {{ __alloy_server_http_listen_port }}
   ansible.posix.firewalld:  # noqa ignore-errors
     immediate: true

--- a/roles/alloy/vars/Suse.yml
+++ b/roles/alloy/vars/Suse.yml
@@ -1,0 +1,2 @@
+---
+__alloy_env_file: "/etc/sysconfig/alloy"


### PR DESCRIPTION
Enables Alloy installation on SUSE-based systems by:
- Adding Suse.yml vars file with sysconfig env path
- Creating setup-Suse.yml task using zypper package manager
- Updating deploy.yml to include SUSE setup tasks

Follows existing Debian/RedHat patterns for consistency.

Close: #422