### PR TITLE
Fix regex_search result handling: replace None with [] for safe length checks

### DIFF
--- a/roles/alloy/tasks/preflight.yml
+++ b/roles/alloy/tasks/preflight.yml
@@ -12,7 +12,7 @@
   block:
     - name: Search for server.http.listen-addr string
       ansible.builtin.set_fact:
-        __alloy_server_http_listen_addr_regex: "{{ alloy_env_file_vars.CUSTOM_ARGS | regex_search('--server.http.listen-addr=([\\d\\.]+):(\\d+)', '\\1', '\\2') }}"
+        __alloy_server_http_listen_addr_regex: "{{ alloy_env_file_vars.CUSTOM_ARGS | regex_search('--server.http.listen-addr=([\\d\\.]+):(\\d+)', '\\1', '\\2') or [] }}"
 
     - name: Extract IP address and port
       ansible.builtin.set_fact:


### PR DESCRIPTION
Fix: https://github.com/grafana/grafana-ansible-collection/issues/413

Now, if the regex does not find anything, it returns `[]` instead of `None`.