### PR TITLE
(#427)(mimir) Fix Mimir config file validation task

### DIFF
--- a/roles/mimir/tasks/deploy.yml
+++ b/roles/mimir/tasks/deploy.yml
@@ -86,6 +86,8 @@
     group: "mimir"
     mode: "0644"
     validate: "mimir -modules --config.file=%s"
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
   notify:
     - Restart mimir
 


### PR DESCRIPTION
On some systems, Mimir is not installed on PATH, or at least no a path directory that is included, by default, for non-interactive shells.

This change explicitly adds `/usr/local/bin` to PATH when validating the config as this is where it is installed on some distributions.

I have tested this change against Rocky Linux, and it fixes #427 on that distribution.