### PR TITLE
Alloy - Migrate RedHat install to ansible.builtin.package

### DIFF
--- a/roles/alloy/tasks/setup-RedHat.yml
+++ b/roles/alloy/tasks/setup-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: DNF - Install Alloy from remote URL
-  ansible.builtin.dnf:
+  ansible.builtin.package:
     name: "{{ alloy_download_url_rpm }}"
     state: present
     disable_gpg_check: true

--- a/roles/alloy/tasks/uninstall.yml
+++ b/roles/alloy/tasks/uninstall.yml
@@ -11,7 +11,7 @@
   failed_when: false
 
 - name: Uninstall Alloy rpm package
-  ansible.builtin.dnf:
+  ansible.builtin.package:
     name: "alloy"
     state: absent
     autoremove: true


### PR DESCRIPTION
I'm installing alloy on several versions of RedHat-based operating systems and the most reliable way to support yum/dnf on 6/7/8/9 is with the `ansible.builtin.package` module instead of `ansible.builtin.dnf`.