### PR TITLE
[Fix #438] Corrects usage of regex_replace on a list

### DIFF
--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -189,11 +189,11 @@
             owner: "grafana"
             group: "grafana"
             mode: "0755"
-          loop: "{{ __dashboards_subdirs.files | map(attribute='path') | sort | regex_replace(grafana_dashboards_dir + '/*', '') }}"
+          loop: "{{ __dashboards_subdirs.files | map(attribute='path') | sort | map('regex_replace', grafana_dashboards_dir + '/*', '') }}"
           become: true
           register: __dashboards_dir_created
           when: not ansible_check_mode
-          
+
         - name: "Copy dashboard files"
           ansible.builtin.copy:
             src: "{{ item.path }}"
@@ -230,7 +230,7 @@
         state: absent
       loop: "{{ __dashboards_present_list | difference(__dashboards_copied_list) }}"
       become: true
-      when: 
+      when:
         - __dashboards_present_list is defined and __dashboards_present_list
         - __dashboards_copied_list is defined and __dashboards_copied_list
         - grafana_provisioning_synced | bool


### PR DESCRIPTION
As found in #438, the `regex_replace` is being performed on a list object.  The `regex_replace` instead needs to be encapsulated into a `map()` function to act on each item.  