### PR TITLE
Run molecule only when required

### DIFF
--- a/.github/workflows/alloy-molecule.yml
+++ b/.github/workflows/alloy-molecule.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/alloy/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'roles/alloy/**'
 
 defaults:
   run:

--- a/.github/workflows/loki-molecule.yml
+++ b/.github/workflows/loki-molecule.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/loki/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'roles/loki/**'
 
 defaults:
   run:

--- a/.github/workflows/mimir-molecule.yml
+++ b/.github/workflows/mimir-molecule.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/mimir/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'roles/mimir/**'
 
 defaults:
   run:

--- a/.github/workflows/opentelemetry-collector-molecule.yml
+++ b/.github/workflows/opentelemetry-collector-molecule.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/opentelemetry_collector/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'roles/opentelemetry_collector/**'
 
 defaults:
   run:

--- a/.github/workflows/promtail-molecule.yml
+++ b/.github/workflows/promtail-molecule.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'roles/promtail/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'roles/promtail/**'
 
 defaults:
   run:

--- a/roles/alloy/tasks/preflight.yml
+++ b/roles/alloy/tasks/preflight.yml
@@ -12,7 +12,7 @@
   block:
     - name: Search for server.http.listen-addr string
       ansible.builtin.set_fact:
-        __alloy_server_http_listen_addr_regex: "{{ alloy_env_file_vars.CUSTOM_ARGS | regex_search('--server.http.listen-addr=([\\d\\.]+):(\\d+)', '\\1', '\\2') }}"
+        __alloy_server_http_listen_addr_regex: "{{ alloy_env_file_vars.CUSTOM_ARGS | regex_search('--server.http.listen-addr=([\\d\\.]+):(\\d+)', '\\1', '\\2') or [] }}"
 
     - name: Extract IP address and port
       ansible.builtin.set_fact:


### PR DESCRIPTION
Currently, any PR to the collection triggers all Molecule tests. This change modifies that behavior so that only the Molecule tests for a role are executed when there are actual changes in that role.

This behavior now applies to `alloy`, `mimir`, `loki`, `opentelemetry_collector`, and `promtail`.