### PR TITLE
Fix mimir automatic version determination

### DIFF
--- a/roles/mimir/tasks/deploy.yml
+++ b/roles/mimir/tasks/deploy.yml
@@ -15,7 +15,7 @@
 
     - name: Latest available Mimir version
       ansible.builtin.set_fact:
-        mimir_version: "{{ __github_latest_version.json.tag_name | regex_replace('^v?(\\d+\\.\\d+\\.\\d+)$', '\\1') }}"
+        mimir_version: "{{ __github_latest_version.json.tag_name | regex_replace('^mimir\\-(\\d+\\.\\d+\\.\\d+)$', '\\1') }}"
 
 - name: Verify current deployed version
   block:

--- a/roles/mimir/tasks/deploy.yml
+++ b/roles/mimir/tasks/deploy.yml
@@ -15,7 +15,7 @@
 
     - name: Latest available Mimir version
       ansible.builtin.set_fact:
-        mimir_version: "{{ __github_latest_version.json.tag_name | regex_replace('^mimir\\-(\\d+\\.\\d+\\.\\d+)$', '\\1') }}"
+        mimir_version: "{{ __github_latest_version.json.tag_name | regex_replace('^(?:mimir\\-|v?)(\\d+\\.\\d+\\.\\d+)$', '\\1') }}"
 
 - name: Verify current deployed version
   block:


### PR DESCRIPTION
If mimir_version is set to `latest`  the version is determined from the latest tag on github.

Afterwards the download fails because the download link would include mimir two times:
```
Failure downloading https://github.com/grafana/mimir/releases/download/mimir-mimir-2.17.2/mimir-mimir-2.17.2_amd64.deb, HTTP Error 404: Not Found
```

This pull request changes the mimir_version regex_replace to replace the `mimir-` prefix of the automatic determined version.

Fixes: #451 