### PR TITLE
Allow to define mimir target

### DIFF
--- a/roles/mimir/README.md
+++ b/roles/mimir/README.md
@@ -83,10 +83,11 @@ You can also run commands like `molecule destroy`, `molecule prepare`, and `mole
 | mimir_ruler.alertmanager_url            | str  | http://127.0.0.1:8080/alertmanager     | Used to specify the URL or address of the Alertmanager API that the Mimir ruler component of the Grafana Agent should communicate with.                              |
 | mimir_ruler.ring.heartbeat_period       | str  | 2s                                     | Used to specify the interval at which the Mimir ruler component of the Grafana Agent sends heartbeat signals to the ring.                                            |
 | mimir_ruler.heartbeat_timeout           | str  | 10s                                    | Used to specify the maximum duration of time that the Mimir ruler component of the Grafana Agent will wait for a heartbeat signal from other components in the ring. |
-| mimir_alertmanager.data_dir             | str  | /data/alertmanager                     | sed to specify the directory path where the Mimir Alertmanager component of the Grafana Agent stores its data files.                                                 |
+| mimir_alertmanager.data_dir             | str  | /data/alertmanager                     | Used to specify the directory path where the Mimir Alertmanager component of the Grafana Agent stores its data files.                                                |
 | mimir_alertmanager.fallback_config_file | str  | /etc/alertmanager-fallback-config.yaml | Used to specify the path to a fallback configuration file for the Mimir Alertmanager component of the Grafana Agent.                                                 |
 | mimir_alertmanager.external_url         | str  | http://localhost:9009/alertmanager     | Used to specify the external URL or address at which the Mimir Alertmanager component of the Grafana Agent can be accessed.                                          |
 | mimir_memberlist.join_members           | []   | List of members for the Mimir cluster  |
+| mimir_targets                           | []   | [all,alertmanager,overrides-exporter]  | Used to specify the list of Mimir components | 
 
 ## **Additional Config Variables for `/etc/mimir/config.yml`**
 

--- a/roles/mimir/defaults/main.yml
+++ b/roles/mimir/defaults/main.yml
@@ -9,6 +9,10 @@ mimir_working_path: "/var/lib/mimir"
 mimir_ruler_alert_path: "{{ mimir_working_path }}/ruler"
 mimir_http_listen_port: 8080
 mimir_http_listen_address: "0.0.0.0"
+mimir_targets:
+  - 'all'
+  - 'alertmanager'
+  - 'overrides-exporter'
 
 arch_mapping:
   x86_64: amd64

--- a/roles/mimir/tasks/deploy.yml
+++ b/roles/mimir/tasks/deploy.yml
@@ -15,7 +15,7 @@
 
     - name: Latest available Mimir version
       ansible.builtin.set_fact:
-        mimir_version: "{{ __github_latest_version.json.tag_name | regex_replace('^v?(\\d+\\.\\d+\\.\\d+)$', '\\1') }}"
+        mimir_version: "{{ __github_latest_version.json.tag_name | regex_replace('^mimir\\-(\\d+\\.\\d+\\.\\d+)$', '\\1') }}"
 
 - name: Verify current deployed version
   block:

--- a/roles/mimir/templates/config.yml.j2
+++ b/roles/mimir/templates/config.yml.j2
@@ -1,5 +1,6 @@
 # Run Mimir in single process mode, with all components running in 1 process.
 target: all,alertmanager,overrides-exporter
+target: {{ mimir_targets | join(',') }}
 
 # Configure Mimir to use Minio as object storage backend.
 common:

--- a/roles/mimir/templates/config.yml.j2
+++ b/roles/mimir/templates/config.yml.j2
@@ -1,5 +1,4 @@
 # Run Mimir in single process mode, with all components running in 1 process.
-target: all,alertmanager,overrides-exporter
 target: {{ mimir_targets | join(',') }}
 
 # Configure Mimir to use Minio as object storage backend.


### PR DESCRIPTION
This pull request builds on top of #461 

Add a new variable to mimir to allow to configure what components should be used.

I choose a list for better readability. This is list is joined to the required string within the config template.

variable:
```yaml
mimir_targets:
  - 'all'
  - 'alertmanager'
  - 'overrides-exporter'
```

template
```
target: all,alertmanager,overrides-exporter
```