### PR TITLE
fix: set owner and group for OpenTelemetry Collector extraction

### DIFF
--- a/roles/opentelemetry_collector/tasks/install.yml
+++ b/roles/opentelemetry_collector/tasks/install.yml
@@ -74,6 +74,8 @@
     src: "/tmp/otelcol-{{ otel_collector_type }}-{{ otel_collector_version }}.tar.gz"
     dest: "{{ otel_collector_installation_dir }}"
     remote_src: yes
+    owner: "{{ otel_collector_service_user }}"
+    group: "{{ otel_collector_service_group }}"
   become: true
   register: extract_result
   when: not ansible_check_mode and otel_collector_installed_version is version(otel_collector_version, '!=')


### PR DESCRIPTION
Unarchive module preserves the original file ownership from the tarball unless explicitly set. This may not match otel uid/gid. Currently set to 1001/1001:
```
tar -tvf  otelcol-contrib_0.140.1_linux_amd64.tar.gz --numeric-owner
-rw-r--r-- 1001/1001      1476 2025-11-19 14:52 README.md
-rwxr-xr-x 1001/1001 355365048 2025-11-19 15:01 otelcol-contrib
```