### PR TITLE
fix(dashboards): resolve loop type error during folder creation

### DIFF
--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -189,7 +189,7 @@
             owner: "grafana"
             group: "grafana"
             mode: "0755"
-          loop: "{{ __dashboards_subdirs.files | map(attribute='path') | sort | regex_replace(grafana_dashboards_dir + '/*', '') }}"
+          loop: "{{ __dashboards_subdirs.files | map(attribute='path') | sort | map('regex_replace', grafana_dashboards_dir + '/*', '') | list }}"
           become: true
           register: __dashboards_dir_created
           when: not ansible_check_mode


### PR DESCRIPTION
This PR fixes a bug in
 https://github.com/grafana/grafana-ansible-collection/blob/4d172fc9228930ccb520508b8db72d088a27e4ae/roles/grafana/tasks/dashboards.yml#L192 
where creating dashboard subdirectories fails due to a strict type-checking error on the `loop` directive. 


### Reproduction:

```yaml
- name: Setup Grafana
  ansible.builtin.import_role:
    name: grafana.grafana.grafana
  vars:
    grafana_ini:
      security:
        admin_password: "{{ grafana_admin_password }}"
    grafana_datasources:
      - name: Prometheus
        type: prometheus
        url: http://localhost:9090
        access: proxy
        is_default: true
    # dashboards is just a folder with JSON dashboard files
    grafana_dashboards_dir: "{{ playbook_dir }}/roles/monitoring/files/dashboards"
```

When running the role with this config, Ansible throws the following error:
`[ERROR]: The loop value must resolve to a 'list', not 'str'.`

<img width="1168" height="270" alt="image" src="https://github.com/user-attachments/assets/5961aafc-fb5c-42b6-a32e-4379b176e22d" />


### Cause:
Currently, the list of sorted paths is piped directly into the `regex_replace` filter. Jinja2 handles this by coercing the entire list into a single string representation and applying the regex to that giant string. The resulting string is then passed to the `loop` directive, which strictly requires a list.

### Fix:
Updated the Jinja2 filter chain to use `map('regex_replace', ...)` so the regex replacement is applied to each path individually. I also added `| list` at the end to force the resulting generator to resolve back into a proper list format that the `loop` directive can consume.

#### Output after fix:
<img width="1656" height="200" alt="image" src="https://github.com/user-attachments/assets/9411829c-c02b-4333-89ba-bfb21e55714f" />
