### PR TITLE
doc: Update datasource Basic auth parameters

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -189,7 +189,12 @@ grafana_datasources: []
 #    url: "http://prometheus.mydomain"
 #    basicAuth: true
 #    basicAuthUser: "admin"
-#    basicAuthPassword: "password"
+#    secureJsonData:
+#      tlsCACert: '...'
+#      tlsClientCert: '...'
+#      tlsClientKey: '...'
+#      password: "password"
+#      basicAuthPassword: "password"
 #    isDefault: true
 #    jsonData:
 #      tlsAuth: false


### PR DESCRIPTION
This PR updates the default comments for the expected configuration for datasources.

Grafana's documentation about datasource provisioning indicates that the passwords should be set in a `secureJsonData` attribute. 

Source: https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-configuration-file