### PR TITLE
fix(grafana): set chdir to homepath for grafana-cli plugin install

### DIFF
--- a/roles/grafana/tasks/plugins.yml
+++ b/roles/grafana/tasks/plugins.yml
@@ -10,6 +10,7 @@
   become: true
   ansible.builtin.command:
     cmd: "grafana-cli --pluginsDir {{ grafana_ini.paths.data }}/plugins plugins install {{ item }}"
+    chdir: /usr/share/grafana
     creates: "{{ grafana_ini.paths.data }}/plugins/{{ item }}"
   loop: "{{ grafana_plugins | difference(__installed_plugins.files) }}"
   register: __plugin_install


### PR DESCRIPTION
Grafana 13 requires grafana-cli to locate its homepath via either the --homepath flag or by running from the homepath as the working directory. Without either, plugin install fails with:

  Grafana-server Init Failed: Could not find config defaults, make sure
  homepath command line parameter is set or working directory is homepath

Set chdir to /usr/share/grafana on the install task so the command runs from the homepath. Restores plugin installation on Grafana 13 and remains a no-op on Grafana <= 12, which already had fallback defaults.

Fixes #497
