### PR TITLE
fix: The loop value must resolve to a 'list', not 'str'

### DIFF
--- a/roles/grafana/tasks/dashboards.yml
+++ b/roles/grafana/tasks/dashboards.yml
@@ -189,7 +189,7 @@
             owner: "grafana"
             group: "grafana"
             mode: "0755"
-          loop: "{{ __dashboards_subdirs.files | map(attribute='path') | sort | regex_replace(grafana_dashboards_dir + '/*', '') }}"
+          loop: "{{ __dashboards_subdirs.files | map(attribute='path') | sort | regex_replace(grafana_dashboards_dir + '/*', '') | list }}"
           become: true
           register: __dashboards_dir_created
           when: not ansible_check_mode


### PR DESCRIPTION
It seems ansible is stricter on type
```
2026-06-20 14:59:43,270 p=1385928 u=user n=ansible INFO| TASK [grafana.grafana.grafana : Create dashboard folders] *****************************************************************************************                                                                                          
2026-06-20 14:59:43,270 p=1385928 u=user n=ansible INFO| Saturday 20 June 2026  14:59:43 +0000 (0:00:00.347)       0:07:06.476 *********           
2026-06-20 14:59:43,307 p=1385928 u=user n=ansible ERROR| [ERROR]: The `loop` value must resolve to a 'list', not 'str'.
Origin: /home/user/Lab1/venv-ansible/lib64/python3.13/site-packages/ansible_collections/grafana/grafana/roles/grafana/tasks/dashboards.yml:197:17
195             group: "grafana" 
196             mode: "0755" 
197           loop: "{{ __dashboards_subdirs.files | map(attribute='path') | sort | regex_replace(grafana_dashboards_...                                               ^ column 17

Provide a list of items/templates, or a template resolving to a list.
```
