### PR TITLE
Wait for DB migrations to complete

### DIFF
--- a/roles/grafana/tasks/configure.yml
+++ b/roles/grafana/tasks/configure.yml
@@ -105,3 +105,14 @@
     enabled: true
     state: started
     daemon_reload: true
+
+- name: Wait for DB migrations to complete
+  ansible.builtin.uri:
+    url: "{{ grafana_ini.server.protocol | default('http') }}/{{ grafana_ini.server.http_addr }}:{{ grafana_ini.server.http_port }}/api/health"
+    follow_redirects: none
+    register: grafana_health
+    retries: 10
+    delay: 5
+  until: grafana_health.json.database == 'ok'
+  when:
+    - grafana_ini.server.protocol is undefined or grafana_ini.server.protocol in ['http', 'https']


### PR DESCRIPTION
Since implementation of Unified Storage in Grafana, deployment role is prone to race conditions during deployments. In case no plugins are defined, handlers are flushed almost immideately, before DB migrations can finish.

This leaves Grafana in an incosistent state, where all futher service restart will fail until database is manually wiped.

Adding a check for API state before proceeding with other tasks ensures that initial startup was fully completed.

Signed-off-by: Dmitriy Rabotyagov <noonedeadpunk@gmail.com>