### PR TITLE
feat(otel): Add support for passing extra args

### DIFF
--- a/roles/opentelemetry_collector/defaults/main.yml
+++ b/roles/opentelemetry_collector/defaults/main.yml
@@ -21,6 +21,8 @@ otel_collector_config_file: "config.yaml"
 otel_collector_service_user: "otel"
 otel_collector_service_group: "otel"
 otel_collector_service_statedirectory: "otel-collector"
+# Extra arguments to pass to the otel-collector binary
+otel_collector_extra_args: ""
 
 otel_collector_receivers: ""
 otel_collector_exporters: ""

--- a/roles/opentelemetry_collector/templates/otel_collector.service.j2
+++ b/roles/opentelemetry_collector/templates/otel_collector.service.j2
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart={{ otel_collector_installation_dir }}/{{ otel_collector_executable }} --config={{ otel_collector_config_dir }}/{{ otel_collector_config_file }}
+ExecStart={{ otel_collector_installation_dir }}/{{ otel_collector_executable }} --config={{ otel_collector_config_dir }}/{{ otel_collector_config_file }} {{ otel_collector_extra_args }}
 User={{ otel_collector_service_user }}
 Group={{ otel_collector_service_group }}
 Restart=on-failure


### PR DESCRIPTION
This commit adds support for passing extra arguments to the otel collector binary.

For example, to enable feature gates:
```
--feature-gates=connector.spanmetrics.legacyMetricNames
```