### PR TITLE
fix issue grafana#533

### DIFF
--- a/roles/grafana/tasks/install.yml
+++ b/roles/grafana/tasks/install.yml
@@ -32,7 +32,7 @@
         enabled: true
         disable_gpg_check : "{{ false if (grafana_yum_key) else omit }}"
         runrefresh: true
-      when: "(not grafana_rhsm_repo)"
+      when: grafana_rhsm_repo is not defined or grafana_rhsm_repo | length == 0
 
 - name: "Prepare yum/dnf"
   when:
@@ -49,26 +49,25 @@
         gpgkey: "{{ grafana_yum_key | default(omit) }}"
         repo_gpgcheck: "{{ true if (grafana_yum_key) else omit }}"
         gpgcheck: "{{ true if (grafana_yum_key) else omit }}"
-      when: "(not grafana_rhsm_repo)"
+      when: grafana_rhsm_repo is not defined or grafana_rhsm_repo | length == 0
 
     - name: "Attach RHSM subscription"
-      when: "(grafana_rhsm_subscription)"
+      when:
+        - grafana_rhsm_subscription is defined
+        - grafana_rhsm_subscription | length > 0
       block:
         - name: "Check if Grafana RHSM subscription is enabled"
           ansible.builtin.command:
             cmd: "subscription-manager list --consumed --matches={{ grafana_rhsm_subscription | quote }} --pool-only"
           register: __subscription_manager_consumed
           changed_when: false
-          when: (grafana_rhsm_subscription)
 
         - name: "Find RHSM repo subscription pool id"
           ansible.builtin.command:
             cmd: "subscription-manager list --available --matches={{ grafana_rhsm_subscription | quote }} --pool-only"
           register: __subscription_manager_available
           changed_when: false
-          when:
-            - "(grafana_rhsm_subscription)"
-            - "__subscription_manager_consumed.stdout | length <= 0"
+          when: "__subscription_manager_consumed.stdout | length <= 0"
 
         - name: "Attach RHSM subscription"
           ansible.builtin.command:
@@ -77,7 +76,6 @@
           changed_when: "__subscription_manager_attach.stdout is search('Successfully attached a subscription')"
           failed_when: "__subscription_manager_attach.stdout is search('could not be found')"
           when:
-            - "(grafana_rhsm_subscription)"
             - "__subscription_manager_consumed.stdout | default() | length <= 0"
             - "__subscription_manager_available.stdout | default() | length > 0"
 
@@ -85,7 +83,9 @@
       community.general.rhsm_repository:
         name: "{{ grafana_rhsm_repo }}"
         state: enabled
-      when: (grafana_rhsm_repo)
+      when:
+        - grafana_rhsm_repo is defined
+        - grafana_rhsm_repo | length > 0
 
 - name: "Prepare apt"
   when:


### PR DESCRIPTION
Hi,

The grafana role breaks on task `install.yml` on Ansible >= 2.20 due to a breaking change in how conditionals are managed.

```
TASK [grafana.grafana.grafana : Check if Grafana RHSM subscription is enabled] ******************************************************************************************************************************************************************
[ERROR]: Task failed: Conditional result (False) was derived from value of type 'str' at '/home/luc/.ansible/collections/ansible_collections/grafana/grafana/roles/grafana/defaults/main.yml:8:28'. Conditionals must have a boolean result.

Task failed.
Origin: /home/luc/.ansible/collections/ansible_collections/grafana/grafana/roles/grafana/tasks/install.yml:57:11

55       when: "(grafana_rhsm_subscription)"
56       block:
57         - name: "Check if Grafana RHSM subscription is enabled"
             ^ column 11

<<< caused by >>>

Conditional result (False) was derived from value of type 'str' at '/home/luc/.ansible/collections/ansible_collections/grafana/grafana/roles/grafana/defaults/main.yml:8:28'. Conditionals must have a boolean result.
Origin: /home/luc/.ansible/collections/ansible_collections/grafana/grafana/roles/grafana/tasks/install.yml:55:13

53
54     - name: "Attach RHSM subscription"
55       when: "(grafana_rhsm_subscription)"
               ^ column 13

Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.

fatal: [acme-monitoring]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result (False) was derived from value of type 'str' at '/home/luc/.ansible/collections/ansible_collections/grafana/grafana/roles/grafana/defaults/main.yml:8:28'. Conditionals must have a boolean result."}
```

I'm also encountering this problem with `grafana_rhsm_repo` variable

Regards