### PR TITLE
fix(alert_contact_point): handle 409 response for duplicate contact points

### DIFF
--- a/plugins/modules/alert_contact_point.py
+++ b/plugins/modules/alert_contact_point.py
@@ -153,7 +153,7 @@ def present_alert_contact_point(module):
 
     if result.status_code == 202:
         return False, True, result.json()
-    elif result.status_code == 500:
+    elif result.status_code in (409, 500):
         sameConfig = False
         contactPointInfo = {}
 


### PR DESCRIPTION
## Summary
- Grafana returns 409 (not 500) when a contact point with the given UID already exists, which breaks idempotency on re-run
- Extend the existing duplicate-handling branch to also match on 409

Fixes #335

## Test plan
- Tested against a live Grafana 12.4.5 instance, fix appears to work