### PR TITLE
grafana/install.yml: add "module_hotfixes: true"

### DIFF
--- a/roles/grafana/tasks/install.yml
+++ b/roles/grafana/tasks/install.yml
@@ -49,6 +49,7 @@
         gpgkey: "{{ grafana_yum_key | default(omit) }}"
         repo_gpgcheck: "{{ true if (grafana_yum_key) else omit }}"
         gpgcheck: "{{ true if (grafana_yum_key) else omit }}"
+        module_hotfixes: true
       when: "(not grafana_rhsm_repo)"
 
     - name: "Attach RHSM subscription"


### PR DESCRIPTION
Without this option, yum/dnf will pick system repositories over grafana's repository. Thus, when installing grafana, it'll default over to the system package vs grafana's. This I believe was not a intended behavior, since we want to use the package provided from grafana (hence why we're adding the repository).

See: https://dnf.readthedocs.io/en/latest/modularity.html#hotfix-repositories