### PR TITLE
fix: skip firewalld rule removal when service is inactive

### DIFF
--- a/roles/alloy/tasks/uninstall.yml
+++ b/roles/alloy/tasks/uninstall.yml
@@ -36,13 +36,23 @@
     state: absent
   when: ansible_facts['os_family'] == 'Suse'
 
+- name: Get firewalld state
+  ansible.builtin.systemd:
+    name: "firewalld"
+  register: __firewalld_service_state
+  when: ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
+
+# Uninstall should mirror Deploy conditions
 - name: Ensure that Alloy firewalld rule is not present - tcp port {{ __alloy_server_http_listen_port }}
-  ansible.posix.firewalld:  # noqa ignore-errors
+  ansible.posix.firewalld:
     immediate: true
     permanent: true
     port: "{{ __alloy_server_http_listen_port }}/tcp"
     state: disabled
-  ignore_errors: true
+  when:
+    - ansible_facts['os_family'] in ['RedHat', 'Debian', 'Suse']
+    - __firewalld_service_state.status.ActiveState == "active"
+    - alloy_expose_port | bool
 
 - name: Remove Alloy directories
   ansible.builtin.file:


### PR DESCRIPTION
## Description

Fixes #523

### Problem
The Alloy role's uninstall task fails fatally when firewalld is not installed on the target system, even though `ignore_errors: true` is specified.

### Root Cause
The `ansible.posix.firewalld` module requires the Python `firewall` library to be imported. When firewalld is not installed:
- The module fails at import time with: `Failed to import the required Python library (firewall)`
- This causes a **fatal error** that cannot be caught by `ignore_errors: true`
- The `ignore_errors` directive only suppresses task execution errors, not module import failures

### Current Behavior
When running uninstall with `alloy_uninstall: true` on a system without firewalld:
```
TASK [grafana.grafana.alloy : Ensure that Alloy firewalld rule is not present - tcp port 12345] ****
[ERROR]: Task failed: Module failed: Failed to import the required Python library (firewall) on XXXX's Python /usr/bin/python3.11. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter. Version 0.2.11 or newer required (0.3.9 or newer for offline operations)
Origin: /XXXX/.local/lib/python3.14/site-packages/ansible_collections/grafana/grafana/roles/alloy/tasks/uninstall.yml:39:3

37   when: ansible_facts['os_family'] == 'Suse'
38
39 - name: Ensure that Alloy firewalld rule is not present - tcp port {{ __alloy_server_http_listen_port }}
     ^ column 3

fatal: [XXXX]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (firewall) on XXXX's Python /usr/bin/python3.11. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter. Version 0.2.11 or newer required (0.3.9 or newer for offline operations)"}
...ignoring
```

This is:
- ❌ Unexpected behavior (task should be skipped, not failed)
- ❌ Creates confusing task output
- ❌ Inconsistent with the deploy phase, which properly skips firewalld tasks

### Solution
Add conditional `when` clauses to the uninstall firewalld task that **skip it entirely** when firewalld is not active, matching the deploy task behavior.

#### Changes:
1. Add a "Get firewalld state" task (identical to deploy.yml)
2. Add conditional `when` clause to the firewalld disable task (mirroring the one in deploy.yml):
   - Check if OS family supports firewalld
   - Check if firewalld service is active
   - Check if `alloy_expose_port` was enabled (only remove what was added)
3. Remove `ignore_errors: true` (no longer needed when task is conditionally skipped)

#### Why This is Better
- **Proper idempotency**: Uninstall only attempts to remove what was added during deploy
- **Consistent logic**: Deploy and uninstall now have symmetrical firewalld handling
- **No false negatives**: No more confusing error messages that get silently ignored
- **Defensive**: Prevents module import failures before they occur

### Related
This same pattern issue exists in other roles (like Promtail) and they should be fixed similarly in follow-up PRs. See example:
https://github.com/grafana/grafana-ansible-collection/blob/521b006dabf4f605e9663c6539bfdec653badb1b/roles/promtail/tasks/uninstall.yml#L90-L96